### PR TITLE
Fix portrait scale crop

### DIFF
--- a/lib/domain/entities/transform_data.dart
+++ b/lib/domain/entities/transform_data.dart
@@ -22,7 +22,7 @@ class TransformData {
     final double yScale = layout.height / rect.height;
 
     final double scale = videoAspect < 0.8
-        ? relativeAspect < 0.8
+        ? relativeAspect <= 1
             ? yScale
             : xScale + videoAspect
         : relativeAspect < 0.8


### PR DESCRIPTION
After cropping portrait video, the `CropGrid` is not the same width than the screen. But it worked fine on landscape video.
I am not completely sure about this fix, but it seems to work every time i tested it.