### PR TITLE
Fix crop grid rotation

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -397,6 +397,22 @@ class CropScreen extends StatelessWidget {
         child: Padding(
           padding: Margin.all(30),
           child: Column(children: [
+            Row(children: [
+              Expanded(
+                child: GestureDetector(
+                  onTap: () => controller.rotate90Degrees(RotateDirection.left),
+                  child: Icon(Icons.rotate_left),
+                ),
+              ),
+              Expanded(
+                child: GestureDetector(
+                  onTap: () =>
+                      controller.rotate90Degrees(RotateDirection.right),
+                  child: Icon(Icons.rotate_right),
+                ),
+              )
+            ]),
+            SizedBox(height: 15),
             Expanded(
               child: AnimatedInteractiveViewer(
                 maxScale: 2.4,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -400,7 +400,8 @@ class CropScreen extends StatelessWidget {
             Expanded(
               child: AnimatedInteractiveViewer(
                 maxScale: 2.4,
-                child: CropGridViewer(controller: controller),
+                child: CropGridViewer(
+                    controller: controller, horizontalMargin: 60),
               ),
             ),
             SizedBox(height: 15),

--- a/lib/ui/crop/crop_grid.dart
+++ b/lib/ui/crop/crop_grid.dart
@@ -90,18 +90,22 @@ class _CropGridViewerState extends State<CropGridViewer> {
     _transform.value = TransformData.fromController(_controller);
     if (_preferredCropAspectRatio == null ||
         _controller.preferredCropAspectRatio != _preferredCropAspectRatio) {
-      setState(() {
-        _preferredCropAspectRatio = _controller.preferredCropAspectRatio;
-        _rect.value = _calculateCropRect(
-          _controller.cacheMinCrop,
-          _controller.cacheMaxCrop,
-        );
-        _changeRect();
-        _onPanEnd(force: true);
-      });
+      _preferredCropAspectRatio = _controller.preferredCropAspectRatio;
+      _calculatePreferedCrop();
     } else {
       _onPanEnd(force: true);
     }
+  }
+
+  void _calculatePreferedCrop() {
+    setState(() {
+      _rect.value = _calculateCropRect(
+        _controller.cacheMinCrop,
+        _controller.cacheMaxCrop,
+      );
+      _changeRect();
+      _onPanEnd(force: true);
+    });
   }
 
   void _scaleRect() {
@@ -317,8 +321,7 @@ class _CropGridViewerState extends State<CropGridViewer> {
           child: Container(
               constraints: BoxConstraints(
                   maxHeight: ((_controller.rotation == 90 ||
-                              _controller.rotation == 270) &&
-                          widget.showGrid)
+                          _controller.rotation == 270))
                       ? MediaQuery.of(context).size.width -
                           widget.horizontalMargin
                       : Size.infinite.height),
@@ -331,7 +334,13 @@ class _CropGridViewerState extends State<CropGridViewer> {
                           Size(constraints.maxWidth, constraints.maxHeight);
                       if (_layout != size) {
                         _layout = size;
-                        _rect.value = _calculateCropRect();
+                        if (widget.showGrid) {
+                          WidgetsBinding.instance!.addPostFrameCallback((_) {
+                            _calculatePreferedCrop();
+                          });
+                        } else {
+                          _rect.value = _calculateCropRect();
+                        }
                       }
                       return widget.showGrid
                           ? Stack(children: [


### PR DESCRIPTION
Currently when the video is in portrait and is rotated, the crop grid width appear bigger than the actual screen width.
I think there is a problem because of the rotation.

By fixing it i forced the crop grid to not be bigger than screen width (+ an external margin that can be provided).
Because the layout size can change, we must compute the preferredCropAspectRatio crop every time.

I added rotation buttons in the CropScreen in the example so it is easier to test it.

## Before
![IMG_5504](https://user-images.githubusercontent.com/22376981/130040503-4c49628b-8e61-4a9a-9031-6d2e5ff4a442.PNG)

## After
![IMG_5505](https://user-images.githubusercontent.com/22376981/130040621-68d683fd-cd1d-4f18-8a20-1adcd004c468.PNG)


