### PR TITLE
Improve cover exportation + apply cover quality in thumbnail

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,26 @@ ext.flutterFFmpegPackage = "min-gpl-lts"
 
 <br><br>
 
+## FAQ
+
+1. Crash on release mode in android
+
+Add the following entries into your `proguard-rules.pro` file. fix: [tanersener/mobile-ffmpeg#616 (comment)](https://github.com/tanersener/mobile-ffmpeg/issues/616#issuecomment-740501984)
+
+```
+-keep class com.arthenica.mobileffmpeg.Config {
+    native <methods>;
+    void log(long, int, byte[]);
+    void statistics(long, int, float, float, long , int, double, double);
+}
+
+-keep class com.arthenica.mobileffmpeg.AbiDetect {
+    native <methods>;
+}
+```
+
+<br><br>
+
 ## Main Contributors
 
 <table>

--- a/lib/domain/bloc/controller.dart
+++ b/lib/domain/bloc/controller.dart
@@ -520,25 +520,30 @@ class VideoEditorController extends ChangeNotifier {
   //------------//
 
   ///Generate cover as a [File]
-  Future<String?> _generateCoverFile() async {
+  Future<String?> _generateCoverFile({
+    int quality = 100,
+  }) async {
     return await VideoThumbnail.thumbnailFile(
       imageFormat: ImageFormat.JPEG,
       video: file.path,
       timeMs: selectedCoverVal?.timeMs ?? startTrim.inMilliseconds,
-      quality: 1000,
+      quality: quality,
     );
   }
 
-  /// Extract the current cover selected by the user, or by default the first one
+  /// Extract the current cover selected by the user, or by default the first one into a JPG image
   Future<File?> extractCover({
     String? name,
     double scale = 1.0,
+    int quality = 100,
     void Function(Statistics)? onProgress,
   }) async {
     final FlutterFFmpegConfig _config = FlutterFFmpegConfig();
     final String tempPath = (await getTemporaryDirectory()).path;
-    final String? _coverPath =
-        await _generateCoverFile(); // file generated from the thumbnail library or video source
+    // file generated from the thumbnail library or video source
+    final String? _coverPath = await _generateCoverFile(
+      quality: quality,
+    );
     if (_coverPath == null) {
       print("ERROR ON COVER EXTRACTION WITH VideoThumbnail LIBRARY");
       return null;

--- a/lib/ui/cover/cover_selection.dart
+++ b/lib/ui/cover/cover_selection.dart
@@ -110,7 +110,7 @@ class _CoverSelectionState extends State<CoverSelection>
                   ? (eachPart * i) + widget.controller.startTrim.inMilliseconds
                   : (eachPart * i))
               .toInt(),
-          quality: 10);
+          quality: widget.quality);
 
       if (_bytes.thumbData != null) {
         _byteList.add(_bytes);


### PR DESCRIPTION
1. The quality param was not applied in `CoverSelection`.
2. By using `ffmpeg` to generate the cover image, the result image could be different to the one selected with `VideoThumbnail` library even when using the same time position. It is because `ffmpeg` uses keyframes to seek to the video position ([source](https://trac.ffmpeg.org/wiki/Seeking)) so the position is not accurate (i noticed difference up to 4ms). By using `VideoThumbnail` library to generate the cover and then using `ffmpeg` to transform the image the issue is fixed.
3. Add an explanation on how to fix android issue in release mode in the `read.me`. https://github.com/seel-channel/video_editor/issues/41#issuecomment-950561036