### PR TITLE
Fix exportation directory issues + add exportation parameters (cover format and exportation directory)

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -137,9 +137,15 @@ class _VideoEditorState extends State<VideoEditor> {
     setState(() => _exported = false);
     final File? cover = await _controller.extractCover();
 
-    if (cover != null)
+    if (cover != null) {
       _exportText = "Cover exported! ${cover.path}";
-    else
+      showModalBottomSheet(
+        context: context,
+        backgroundColor: Colors.black54,
+        builder: (BuildContext context) =>
+            Image.memory(cover.readAsBytesSync()),
+      );
+    } else
       _exportText = "Error on cover exportation :(";
 
     setState(() => _exported = true);

--- a/lib/domain/bloc/controller.dart
+++ b/lib/domain/bloc/controller.dart
@@ -585,8 +585,7 @@ class VideoEditorController extends ChangeNotifier {
     filters.removeWhere((item) => item.isEmpty);
     final String filter =
         filters.isNotEmpty ? "-filter:v " + filters.join(",") : "";
-    final String execute =
-        "-i $_coverPath $filter -y $outputPath"; // TODO : cover file is not overwritten even while using -y param
+    final String execute = "-i $_coverPath $filter -y $outputPath";
 
     //------------------//
     //PROGRESS CALLBACKS//

--- a/lib/domain/bloc/controller.dart
+++ b/lib/domain/bloc/controller.dart
@@ -404,13 +404,13 @@ class VideoEditorController extends ChangeNotifier {
     }
   }
 
-  ///Export the video at `TemporaryDirectory` and return a `File`.
+  ///Export the video using this edition parameters and return a `File`.
   ///
+  ///If the [name] is `null`, then it uses this video filename.
   ///
-  ///If the [name] is `null`, then it uses the filename.
+  ///If the [outDir] is `null`, then it uses `TemporaryDirectory`.
   ///
-  ///
-  ///The [scale] is `scale=width*scale:height*scale` and reduce o increase video size.
+  ///The [scale] is `scale=width*scale:height*scale` and reduce or increase video size.
   ///
   ///The [onProgress] is called while the video is exporting. This argument is usually used to update the export progress percentage.
   ///
@@ -419,6 +419,7 @@ class VideoEditorController extends ChangeNotifier {
   ///**More info about presets**:  https://ffmpeg.org/ffmpeg-formats.htmlhttps://trac.ffmpeg.org/wiki/Encode/H.264
   Future<File?> exportVideo({
     String? name,
+    String? outDir,
     String format = "mp4",
     double scale = 1.0,
     String? customInstruction,
@@ -426,10 +427,10 @@ class VideoEditorController extends ChangeNotifier {
     VideoExportPreset preset = VideoExportPreset.none,
   }) async {
     final FlutterFFmpegConfig _config = FlutterFFmpegConfig();
-    final String tempPath = (await getTemporaryDirectory()).path;
+    final String tempPath = outDir ?? (await getTemporaryDirectory()).path;
     final String videoPath = file.path;
-    if (name == null) name = path.basename(videoPath).split('.')[0];
-    final String outputPath = tempPath + name + ".$format";
+    if (name == null) name = path.basenameWithoutExtension(videoPath);
+    final String outputPath = "$tempPath/$name.$format";
 
     //-----------------//
     //CALCULATE FILTERS//
@@ -519,7 +520,9 @@ class VideoEditorController extends ChangeNotifier {
   //COVER EXPORT//
   //------------//
 
-  ///Generate cover as a [File]
+  ///Generate this selected cover image as a JPEG [File]
+  ///
+  ///If this [selectedCoverVal] is `null`, then it return the first frame of this video.
   Future<String?> _generateCoverFile({
     int quality = 100,
   }) async {
@@ -531,15 +534,24 @@ class VideoEditorController extends ChangeNotifier {
     );
   }
 
-  /// Extract the current cover selected by the user, or by default the first one into a JPG image
+  ///Export this selected cover, or by default the first one, return an image `File`.
+  ///
+  ///If the [name] is `null`, then it uses this video filename.
+  ///
+  ///If the [outDir] is `null`, then it uses `TemporaryDirectory`.
+  ///
+  ///The [scale] is `scale=width*scale:height*scale` and reduce or increase cover size.
+  ///
+  ///The [quality] of the exported image (from 0 to 100)
   Future<File?> extractCover({
     String? name,
+    String? outDir,
     double scale = 1.0,
     int quality = 100,
     void Function(Statistics)? onProgress,
   }) async {
     final FlutterFFmpegConfig _config = FlutterFFmpegConfig();
-    final String tempPath = (await getTemporaryDirectory()).path;
+    final String tempPath = outDir ?? (await getTemporaryDirectory()).path;
     // file generated from the thumbnail library or video source
     final String? _coverPath = await _generateCoverFile(
       quality: quality,
@@ -548,8 +560,8 @@ class VideoEditorController extends ChangeNotifier {
       print("ERROR ON COVER EXTRACTION WITH VideoThumbnail LIBRARY");
       return null;
     }
-    if (name == null) name = path.basename(file.path).split('.')[0];
-    final String outputPath = tempPath + name + ".jpg";
+    if (name == null) name = path.basenameWithoutExtension(file.path);
+    final String outputPath = "$tempPath/$name.jpg";
 
     //-----------------//
     //CALCULATE FILTERS//

--- a/lib/domain/bloc/controller.dart
+++ b/lib/domain/bloc/controller.dart
@@ -410,6 +410,8 @@ class VideoEditorController extends ChangeNotifier {
   ///
   ///If the [outDir] is `null`, then it uses `TemporaryDirectory`.
   ///
+  ///The [format] of the video to be exported, by default `mp4`.
+  ///
   ///The [scale] is `scale=width*scale:height*scale` and reduce or increase video size.
   ///
   ///The [onProgress] is called while the video is exporting. This argument is usually used to update the export progress percentage.
@@ -540,12 +542,15 @@ class VideoEditorController extends ChangeNotifier {
   ///
   ///If the [outDir] is `null`, then it uses `TemporaryDirectory`.
   ///
+  ///The [format] of the image to be exported, by default `jpg`.
+  ///
   ///The [scale] is `scale=width*scale:height*scale` and reduce or increase cover size.
   ///
   ///The [quality] of the exported image (from 0 to 100)
   Future<File?> extractCover({
     String? name,
     String? outDir,
+    String format = "jpg",
     double scale = 1.0,
     int quality = 100,
     void Function(Statistics)? onProgress,
@@ -561,7 +566,7 @@ class VideoEditorController extends ChangeNotifier {
       return null;
     }
     if (name == null) name = path.basenameWithoutExtension(file.path);
-    final String outputPath = "$tempPath/$name.jpg";
+    final String outputPath = "$tempPath/$name.$format";
 
     //-----------------//
     //CALCULATE FILTERS//


### PR DESCRIPTION
- Fix exporting path missing `/` after the exporting directory for video and cover causing the final path to be `/var/mobile/Containers/Data/Application/.../Library/Cachestrim.jpg` instead of `/var/mobile/Containers/Data/Application/.../Library/Caches/trim.jpg`
- Fix the way to get the video file name during exportation to use `path.basenameWithoutExtension(file.path)` instead `path.basename(file.path).split('.')[0]` because when the file has a `.` in it name the final name is not correct
- Add parameter to specify exporting folder with `outDir` for video and cover exportation https://github.com/seel-channel/video_editor/issues/40#issue-1028691172
- Add parameter to specify the format of the cover to be exported (by default `jpg`)
- remove TODO comment because ffmpeg `-y` overwrite works properly
- display exported cover in example