### PR TITLE
Change how video dimensions are computed + update example and libraries

### DIFF
--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>8.0</string>
+  <string>9.0</string>
 </dict>
 </plist>

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:helpers/helpers.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:video_editor/video_editor.dart';
+import 'package:video_player/video_player.dart';
 
 void main() => runApp(MyApp());
 
@@ -41,8 +42,7 @@ class _VideoPickerPageState extends State<VideoPickerPage> {
   final ImagePicker _picker = ImagePicker();
 
   void _pickVideo() async {
-    final PickedFile? file =
-        await _picker.getVideo(source: ImageSource.gallery);
+    final XFile? file = await _picker.pickVideo(source: ImageSource.gallery);
     if (file != null) context.to(VideoEditor(file: File(file.path)));
   }
 
@@ -112,21 +112,41 @@ class _VideoEditorState extends State<VideoEditor> {
   void _openCropScreen() => context.to(CropScreen(controller: _controller));
 
   void _exportVideo() async {
-    Misc.delayed(1000, () => _isExporting.value = true);
+    _isExporting.value = true;
+    bool _firstStat = true;
     //NOTE: To use [-crf 17] and [VideoExportPreset] you need ["min-gpl-lts"] package
     final File? file = await _controller.exportVideo(
       preset: VideoExportPreset.medium,
       customInstruction: "-crf 17",
       onProgress: (statics) {
-        _exportingProgress.value =
-            statics.time / _controller.video.value.duration.inMilliseconds;
+        // First statistics is always wrong so if first one skip it
+        if (_firstStat)
+          _firstStat = false;
+        else
+          _exportingProgress.value =
+              statics.time / _controller.video.value.duration.inMilliseconds;
       },
     );
+    if (!mounted) return;
     _isExporting.value = false;
 
-    if (file != null)
+    if (file != null) {
+      final VideoPlayerController _videoController =
+          VideoPlayerController.file(file);
+      _videoController.initialize().then((value) async {
+        setState(() {});
+        _videoController.play();
+        _videoController.setLooping(true);
+        await showModalBottomSheet(
+          context: context,
+          backgroundColor: Colors.black54,
+          builder: (BuildContext context) => VideoPlayer(_videoController),
+        );
+        _videoController.pause();
+        _videoController.dispose();
+      });
       _exportText = "Video success export!";
-    else
+    } else
       _exportText = "Error on export video :(";
 
     setState(() => _exported = true);
@@ -136,6 +156,7 @@ class _VideoEditorState extends State<VideoEditor> {
   void _exportCover() async {
     setState(() => _exported = false);
     final File? cover = await _controller.extractCover();
+    if (!mounted) return;
 
     if (cover != null) {
       _exportText = "Cover exported! ${cover.path}";

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -15,8 +15,9 @@ dependencies:
     path: ../
 
   helpers: ^1.1.1
-  image_picker: ^0.7.4
+  image_picker: ^0.8.4
   cupertino_icons: ^1.0.2
+  video_player: ^2.2.6
 
 dev_dependencies:
   flutter_test:

--- a/lib/domain/bloc/controller.dart
+++ b/lib/domain/bloc/controller.dart
@@ -69,7 +69,6 @@ class VideoEditorController extends ChangeNotifier {
         this.trimStyle = trimStyle ?? TrimSliderStyle();
 
   FlutterFFmpeg _ffmpeg = FlutterFFmpeg();
-  FlutterFFprobe _ffprobe = FlutterFFprobe();
 
   int _rotation = 0;
   bool _isTrimming = false;

--- a/lib/domain/bloc/controller.dart
+++ b/lib/domain/bloc/controller.dart
@@ -97,8 +97,8 @@ class VideoEditorController extends ChangeNotifier {
   //Cover parameters
   ValueNotifier<CoverData?> _selectedCover = ValueNotifier<CoverData?>(null);
 
-  int _videoWidth = 0;
-  int _videoHeight = 0;
+  double _videoWidth = 0;
+  double _videoHeight = 0;
 
   ///Get the `VideoPlayerController`
   VideoPlayerController get video => _video;
@@ -201,8 +201,10 @@ class VideoEditorController extends ChangeNotifier {
   //----------------//
   ///Attempts to open the given [File] and load metadata about the video.
   Future<void> initialize() async {
-    await _video.initialize();
-    await _getVideoDimensions();
+    await _video.initialize().then((_) {
+      _videoWidth = _video.value.size.width;
+      _videoHeight = _video.value.size.height;
+    });
     _video.addListener(_videoListener);
     _video.setLooping(true);
 
@@ -240,14 +242,13 @@ class VideoEditorController extends ChangeNotifier {
   //VIDEO CROP//
   //----------//
   Future<String> _getCrop() async {
-    await _getVideoDimensions();
     int enddx = (_videoWidth * maxCrop.dx).floor();
     int enddy = (_videoHeight * maxCrop.dy).floor();
     int startdx = (_videoWidth * minCrop.dx).floor();
     int startdy = (_videoHeight * minCrop.dy).floor();
 
-    if (enddx > _videoWidth) enddx = _videoWidth;
-    if (enddy > _videoHeight) enddy = _videoHeight;
+    if (enddx > _videoWidth) enddx = _videoWidth.floor();
+    if (enddy > _videoHeight) enddy = _videoHeight.floor();
     if (startdx < 0) startdx = 0;
     if (startdy < 0) startdy = 0;
     return "crop=${enddx - startdx}:${enddy - startdy}:$startdx:$startdy";
@@ -368,41 +369,6 @@ class VideoEditorController extends ChangeNotifier {
   //------------//
   //VIDEO EXPORT//
   //------------//
-  Future<void> _getVideoDimensions() async {
-    if (!(_videoHeight > 0 && _videoWidth > 0)) {
-      final info = await _ffprobe.getMediaInformation(file.path);
-      final streams = info.getStreams();
-      int _height = 0;
-      int _width = 0;
-
-      if (streams != null && streams.length > 0) {
-        for (var stream in streams) {
-          if (stream.getAllProperties()['codec_type'] == 'video') {
-            _width = stream.getAllProperties()['width'];
-            _height = stream.getAllProperties()['height'];
-
-            //If video is portrait mode use the rotate to adjust
-            final metadataMap = stream.getAllProperties()['side_data_list'];
-            if (metadataMap != null) {
-              for (var metadata in metadataMap) {
-                if (metadata.containsKey('rotation')) {
-                  int rotate = metadata['rotation'];
-                  var rotateTimes = rotate / 90;
-                  if (rotateTimes % 2 != 0) {
-                    _width = stream.getAllProperties()['height'];
-                    _height = stream.getAllProperties()['width'];
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-
-      _videoHeight = _height;
-      _videoWidth = _width;
-    }
-  }
 
   ///Export the video using this edition parameters and return a `File`.
   ///

--- a/lib/ui/cover/cover_viewer.dart
+++ b/lib/ui/cover/cover_viewer.dart
@@ -85,9 +85,9 @@ class _CoverViewerState extends State<CoverViewer> {
             builder: (context, CoverData? selectedCover, __) => selectedCover
                         ?.thumbData ==
                     null
-                ? Text('No selection')
+                ? Center(child: Text('No selection'))
                 : CropTransform(
-                    transform: _transform.value,
+                    transform: transform,
                     child: Center(
                         child: Stack(children: [
                       AspectRatio(

--- a/lib/ui/cover/cover_viewer.dart
+++ b/lib/ui/cover/cover_viewer.dart
@@ -10,10 +10,14 @@ class CoverViewer extends StatefulWidget {
   CoverViewer({
     Key? key,
     required this.controller,
+    this.noCoverText = 'No selection',
   }) : super(key: key);
 
   ///Essential argument for the functioning of the Widget
   final VideoEditorController controller;
+
+  ///Text to display instead of the cover if selected cover data is `null`
+  final String noCoverText;
 
   @override
   _CoverViewerState createState() => _CoverViewerState();
@@ -85,7 +89,7 @@ class _CoverViewerState extends State<CoverViewer> {
             builder: (context, CoverData? selectedCover, __) => selectedCover
                         ?.thumbData ==
                     null
-                ? Center(child: Text('No selection'))
+                ? Center(child: Text(widget.noCoverText))
                 : CropTransform(
                     transform: transform,
                     child: Center(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
 
   path: ^1.8.0
-  video_player: ^2.1.12
+  video_player: ^2.2.6
   path_provider: ^2.0.2
   flutter_ffmpeg: ^0.4.2
   video_thumbnail: ^0.4.3


### PR DESCRIPTION
### In lib:

- Currently the video dimensions are computed using `ffmpeg`, i think it is a heavy implementation that could be done easily using `VideoPlayerController`
```dart
await _video.initialize().then((_) {
  _videoWidth = _video.value.size.width;
  _videoHeight = _video.value.size.height;
});
```
- Add the option to change the `No selection` text in `CoverViewer`
- Update `video_player` library to the latest 2.2.6

### In example:

- Display exported video
- Add `video_player` library
- Update `image_picker` library to the latest 0.8.4 and update code to remove deprecated implementation