### PR TITLE
error MissingPluginException with video_thumbnail

### DIFF
--- a/lib/domain/bloc/controller.dart
+++ b/lib/domain/bloc/controller.dart
@@ -484,6 +484,7 @@ class VideoEditorController extends ChangeNotifier {
   Future<String?> _generateCoverFile({int quality = 100}) async {
     return await VideoThumbnail.thumbnailFile(
       imageFormat: ImageFormat.JPEG,
+      thumbnailPath: (await getTemporaryDirectory()).path,
       video: file.path,
       timeMs: selectedCoverVal?.timeMs ?? startTrim.inMilliseconds,
       quality: quality,


### PR DESCRIPTION
fix `MissingPluginException` exception when exporting cover on android with `VideoThumbnail`.
https://github.com/justsoft/video_thumbnail/issues/59#issuecomment-812725600