### PR TITLE
Add epoch to exportation names by default

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -116,7 +116,6 @@ class _VideoEditorState extends State<VideoEditor> {
     bool _firstStat = true;
     //NOTE: To use [-crf 17] and [VideoExportPreset] you need ["min-gpl-lts"] package
     await _controller.exportVideo(
-      name: DateTime.now().millisecondsSinceEpoch.toString(),
       // preset: VideoExportPreset.medium,
       // customInstruction: "-crf 17",
       onProgress: (statics) {

--- a/lib/domain/bloc/controller.dart
+++ b/lib/domain/bloc/controller.dart
@@ -395,7 +395,8 @@ class VideoEditorController extends ChangeNotifier {
     final String tempPath = outDir ?? (await getTemporaryDirectory()).path;
     final String videoPath = file.path;
     if (name == null) name = path.basenameWithoutExtension(videoPath);
-    final String outputPath = "$tempPath/$name.$format";
+    final int epoch = DateTime.now().millisecondsSinceEpoch;
+    final String outputPath = "$tempPath/${name}_$epoch.$format";
 
     //-----------------//
     //CALCULATE FILTERS//
@@ -522,7 +523,8 @@ class VideoEditorController extends ChangeNotifier {
       return null;
     }
     if (name == null) name = path.basenameWithoutExtension(file.path);
-    final String outputPath = "$tempPath/$name.$format";
+    final int epoch = DateTime.now().millisecondsSinceEpoch;
+    final String outputPath = "$tempPath/${name}_$epoch.$format";
 
     //-----------------//
     //CALCULATE FILTERS//


### PR DESCRIPTION
I think it is important to put an epoch in the output files names to avoid error when the video original file name is the same than the output.

I got this error while trying to edit a video recorded with [camera](https://pub.dev/packages/camera) plugin.

I think it should be added by default at the exportation.