### PR TITLE
print ffmpeg return state and fail stack trace if exists

### DIFF
--- a/lib/domain/bloc/controller.dart
+++ b/lib/domain/bloc/controller.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'dart:typed_data';
 import 'package:ffmpeg_kit_flutter/ffmpeg_kit.dart';
+import 'package:ffmpeg_kit_flutter/ffmpeg_kit_config.dart';
 import 'package:ffmpeg_kit_flutter/ffprobe_kit.dart';
 import 'package:ffmpeg_kit_flutter/media_information_session.dart';
 import 'package:ffmpeg_kit_flutter/statistics.dart';
@@ -445,7 +446,14 @@ class VideoEditorController extends ChangeNotifier {
     await FFmpegKit.executeAsync(
       execute,
       (session) async {
+        final state =
+            FFmpegKitConfig.sessionStateToString(await session.getState());
         final code = await session.getReturnCode();
+        final failStackTrace = await session.getFailStackTrace();
+
+        print(
+            "FFmpeg process exited with state $state and return code $code.${(failStackTrace == null) ? "" : "\\n" + failStackTrace}");
+
         onCompleted(code?.isValueSuccess() == true ? File(outputPath) : null);
       },
       null,
@@ -568,7 +576,14 @@ class VideoEditorController extends ChangeNotifier {
     await FFmpegKit.executeAsync(
       execute,
       (session) async {
+        final state =
+            FFmpegKitConfig.sessionStateToString(await session.getState());
         final code = await session.getReturnCode();
+        final failStackTrace = await session.getFailStackTrace();
+
+        print(
+            "FFmpeg process exited with state $state and return code $code.${(failStackTrace == null) ? "" : "\\n" + failStackTrace}");
+
         onCompleted(code?.isValueSuccess() == true ? File(outputPath) : null);
       },
       null,


### PR DESCRIPTION
Since we migrated from `flutter_ffmpeg` to `ffmpeg_kit` the fail stack trace are not displayed in the log anymore which make error solving difficult https://github.com/seel-channel/video_editor/issues/62, https://github.com/seel-channel/video_editor/issues/61

I followed [flutter ffmpeg_kit test app](https://github.com/tanersener/ffmpeg-kit-test/tree/main/flutter/test-app-pub) way to displayed those log