### PR TITLE
[add] new progress value returned by onProgress in exportVideo

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -124,21 +124,13 @@ class _VideoEditorState extends State<VideoEditor> {
               CropScreen(controller: _controller)));
 
   void _exportVideo() async {
+    _exportingProgress.value = 0;
     _isExporting.value = true;
-    bool _firstStat = true;
     // NOTE: To use `-crf 1` and [VideoExportPreset] you need `ffmpeg_kit_flutter_min_gpl` package (with `ffmpeg_kit` only it won't work)
     await _controller.exportVideo(
       // preset: VideoExportPreset.medium,
       // customInstruction: "-crf 17",
-      onProgress: (statics) {
-        // First statistics is always wrong so if first one skip it
-        if (_firstStat) {
-          _firstStat = false;
-        } else {
-          _exportingProgress.value = statics.getTime() /
-              _controller.video.value.duration.inMilliseconds;
-        }
-      },
+      onProgress: (stats, value) => _exportingProgress.value = value,
       onCompleted: (file) {
         _isExporting.value = false;
         if (!mounted) return;

--- a/lib/domain/bloc/controller.dart
+++ b/lib/domain/bloc/controller.dart
@@ -452,7 +452,9 @@ class VideoEditorController extends ChangeNotifier {
   /// The [customInstruction] param can be set to add custom commands to the FFmpeg eexecution
   /// (i.e. `-an` to mute the generated video), some commands require the GPL package
   ///
-  /// The [onProgress] is called while the video is exporting. This argument is usually used to update the export progress percentage.
+  /// The [onProgress] is called while the video is exporting.
+  /// This argument is usually used to update the export progress percentage.
+  /// This function return [Statistics] from FFmpeg session and the [double] progress value between 0.0 and 1.0.
   ///
   /// The [preset] is the `compress quality` **(Only available on GPL package)**.
   /// A slower preset will provide better compression (compression is quality per filesize).
@@ -466,7 +468,7 @@ class VideoEditorController extends ChangeNotifier {
     String format = "mp4",
     double scale = 1.0,
     String? customInstruction,
-    void Function(Statistics)? onProgress,
+    void Function(Statistics, double)? onProgress,
     VideoExportPreset preset = VideoExportPreset.none,
     bool isFiltersEnabled = true,
   }) async {
@@ -512,7 +514,14 @@ class VideoEditorController extends ChangeNotifier {
         onCompleted(code?.isValueSuccess() == true ? File(outputPath) : null);
       },
       null,
-      onProgress != null ? onProgress : null,
+      onProgress != null
+          ? (stats) {
+              // Progress value of encoded video
+              double progressValue =
+                  stats.getTime() / (_trimEnd - _trimStart).inMilliseconds;
+              onProgress(stats, progressValue.clamp(0.0, 1.0));
+            }
+          : null,
     );
   }
 
@@ -590,6 +599,10 @@ class VideoEditorController extends ChangeNotifier {
   /// The [scale] is `scale=width*scale:height*scale` and reduce or increase cover size.
   ///
   /// The [quality] of the exported image (from 0 to 100 ([more info](https://pub.dev/packages/video_thumbnail)))
+  ///
+  /// The [onProgress] is called while the video is exporting.
+  /// This argument is usually used to update the export progress percentage.
+  /// This function return [Statistics] from FFmpeg session.
   ///
   /// Set [isFiltersEnabled] to `false` if you do not want to apply any changes
   Future<void> extractCover({


### PR DESCRIPTION
The progress value of the video extraction can be a bit tricky because it need to compute the trimmed area duration.
This return this progress value in `onProgress` function of `exportVideo`