### PR TITLE
Fix crop grid : gesture, aspect ratio, and painting area

### DIFF
--- a/lib/domain/bloc/controller.dart
+++ b/lib/domain/bloc/controller.dart
@@ -186,36 +186,9 @@ class VideoEditorController extends ChangeNotifier {
   /// The [preferredCropAspectRatio] param is the selected aspect ratio (9:16, 3:4, 1:1, ...)
   double? get preferredCropAspectRatio => _preferredCropAspectRatio;
   set preferredCropAspectRatio(double? value) {
-    if (value == null) {
-      _preferredCropAspectRatio = value;
-      notifyListeners();
-    } else if (value >= 0) {
-      // TODO : when switching from a preferred aspect ratio to another it keep reducing the crop size
-
-      final length = cropStyle.boundariesLength * 4;
-      final videoWidth = videoDimension.width;
-      final videoHeight = videoDimension.height;
-      final cropHeight = (cacheMaxCrop.dy - cacheMinCrop.dy) * videoHeight;
-      final cropWidth = (cacheMaxCrop.dx - cacheMinCrop.dx) * videoWidth;
-      Offset newMax = Offset(
-        cropWidth / videoWidth,
-        (cropWidth / value) / videoWidth,
-      );
-
-      if (newMax.dy > _max.dy || newMax.dx > _max.dx) {
-        newMax = Offset(
-          (cropHeight * value) / cropHeight,
-          cropHeight / videoHeight,
-        );
-      }
-
-      if ((newMax.dx - cacheMinCrop.dx) * videoWidth > length &&
-          (newMax.dy - cacheMinCrop.dy) * videoHeight > length) {
-        cacheMaxCrop = newMax;
-        _preferredCropAspectRatio = value;
-        notifyListeners();
-      }
-    }
+    if (preferredCropAspectRatio == value) return;
+    _preferredCropAspectRatio = value;
+    notifyListeners();
   }
 
   //----------------//

--- a/lib/ui/cover/cover_selection.dart
+++ b/lib/ui/cover/cover_selection.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:video_editor/domain/entities/cover_data.dart';
 import 'package:video_editor/domain/entities/transform_data.dart';
@@ -37,9 +39,10 @@ class _CoverSelectionState extends State<CoverSelection>
   Duration? _startTrim, _endTrim;
   Size _layout = Size.zero;
   final ValueNotifier<Rect> _rect = ValueNotifier<Rect>(Rect.zero);
-  Stream<List<CoverData>>? _stream;
   final ValueNotifier<TransformData> _transform =
       ValueNotifier<TransformData>(TransformData());
+
+  late Stream<List<CoverData>> _stream = (() => _generateThumbnails())();
 
   @override
   void dispose() {
@@ -145,7 +148,6 @@ class _CoverSelectionState extends State<CoverSelection>
       if (_width != width) {
         _width = width;
         _layout = _calculateLayout();
-        _stream = _generateThumbnails();
         _rect.value = _calculateCoverRect();
       }
 

--- a/lib/ui/crop/crop_grid.dart
+++ b/lib/ui/crop/crop_grid.dart
@@ -199,7 +199,9 @@ class _CropGridViewerState extends State<CropGridViewer> {
     _boundary = _CropBoundaries.none;
 
     if (_expandedRect().contains(pos)) {
-      _boundary = _CropBoundaries.inside;
+      if (_rect.value.contains(pos)) {
+        _boundary = _CropBoundaries.inside;
+      }
 
       // CORNERS
       if (_expandedPosition(_rect.value.topLeft).contains(pos)) {

--- a/lib/ui/crop/crop_grid.dart
+++ b/lib/ui/crop/crop_grid.dart
@@ -86,24 +86,80 @@ class _CropGridViewerState extends State<CropGridViewer> {
     super.dispose();
   }
 
+  /// Update crop [Rect] after change in [_controller] such as change of aspect ratio
   void _updateRect() {
     _transform.value = TransformData.fromController(_controller);
-    if (_preferredCropAspectRatio == null ||
-        _controller.preferredCropAspectRatio != _preferredCropAspectRatio) {
-      _preferredCropAspectRatio = _controller.preferredCropAspectRatio;
-      _calculatePreferedCrop();
-    } else {
-      _onPanEnd(force: true);
-    }
+    _calculatePreferedCrop();
   }
 
+  /// Compute new [Rect] crop area depending of [_controller] data and layout size
   void _calculatePreferedCrop() {
-    setState(() {
-      _rect.value = _calculateCropRect(
-        _controller.cacheMinCrop,
-        _controller.cacheMaxCrop,
+    final _oldRatio = _controller.preferredCropAspectRatio;
+    _preferredCropAspectRatio = _controller.preferredCropAspectRatio;
+
+    // set cached crop values to adjust it later
+    _rect.value = _calculateCropRect(
+      _controller.cacheMinCrop,
+      _controller.cacheMaxCrop,
+    );
+    final double _rectHeight = _rect.value.height;
+    final double _rectWidth = _rect.value.width;
+    Rect _newCrop = _rect.value;
+
+    if (_preferredCropAspectRatio != null) {
+      // if current crop ratio is bigger than new aspect ratio
+      // or if previous ratio smaller than new aspect ratio (so when switching of aspect ratio the crop area is not always getting smaller)
+      // resize on width
+      if (_rectWidth / _rectHeight > _preferredCropAspectRatio! &&
+          (_oldRatio != null && _oldRatio < _preferredCropAspectRatio!)) {
+        final w = _rectHeight * _preferredCropAspectRatio!;
+        _newCrop = Rect.fromLTWH(_rect.value.center.dx - w / 2, _rect.value.top,
+            w, _rect.value.height);
+      } else {
+        // otherwise, resize on height
+        final h = _rectWidth / _preferredCropAspectRatio!;
+        _newCrop = Rect.fromLTWH(_rect.value.left,
+            _rect.value.center.dy - h / 2, _rect.value.width, h);
+      }
+    }
+
+    // if new crop is bigger than available space, block to maximum size and avoid out of bounds
+    if (_newCrop.width > _layout.width) {
+      final _h = _layout.width /
+          (_preferredCropAspectRatio ?? (_rectWidth / _rectHeight));
+      _newCrop = Rect.fromLTWH(
+        0.0,
+        _newCrop.top.clamp(0, _layout.height - _h),
+        _layout.width,
+        _h,
       );
-      _changeRect();
+    } else if (_newCrop.height > _layout.height) {
+      final _w = _layout.height /
+          (_preferredCropAspectRatio ?? (_rectWidth / _rectHeight));
+      _newCrop = Rect.fromLTWH(
+        _newCrop.left.clamp(0, _layout.width - _w),
+        0.0,
+        _w,
+        _layout.height,
+      );
+    } else {
+      // if new crop is out of bounds, translate inside layout
+      if (_newCrop.bottom > _layout.height) {
+        _newCrop = _newCrop.translate(0, _layout.height - _newCrop.bottom);
+      }
+      if (_newCrop.top < 0.0) {
+        _newCrop = _newCrop.translate(0, _newCrop.top.abs());
+      }
+      if (_newCrop.left < 0.0) {
+        _newCrop = _newCrop.translate(_newCrop.left.abs(), 0);
+      }
+      if (_newCrop.right > _layout.width) {
+        _newCrop = _newCrop.translate(_layout.width - _newCrop.right, 0);
+      }
+    }
+
+    setState(() {
+      _rect.value = _newCrop;
       _onPanEnd(force: true);
     });
   }
@@ -122,6 +178,7 @@ class _CropGridViewerState extends State<CropGridViewer> {
     final Offset max = _rect.value.bottomRight;
     final Offset min = _rect.value.topLeft;
 
+    // Use margins to increase grabbable areas
     final List<Offset> minMargin = [min - _margin, min + _margin];
     final List<Offset> maxMargin = [max - _margin, max + _margin];
 
@@ -157,17 +214,12 @@ class _CropGridViewerState extends State<CropGridViewer> {
           _boundary = _CropBoundaries.centerLeft;
         } else if (pos >= topRight.bottomLeft && pos <= bottomRight.topRight) {
           _boundary = _CropBoundaries.centerRight;
-        }
-        //OTHERS
-        else if (pos >= minMargin[1] && pos <= maxMargin[0]) {
-          _boundary = _CropBoundaries.inside;
         } else {
-          _boundary = _CropBoundaries.none;
+          //OTHERS
+          _boundary = _CropBoundaries.inside;
         }
-      } else if (pos >= minMargin[1] && pos <= maxMargin[0]) {
-        _boundary = _CropBoundaries.inside;
       } else {
-        _boundary = _CropBoundaries.none;
+        _boundary = _CropBoundaries.inside;
       }
     } else {
       _boundary = _CropBoundaries.none;
@@ -182,65 +234,41 @@ class _CropGridViewerState extends State<CropGridViewer> {
       switch (_boundary) {
         case _CropBoundaries.inside:
           final Offset pos = _rect.value.topLeft + delta;
-          _changeRect(left: pos.dx, top: pos.dy);
+          _rect.value = Rect.fromLTWH(
+              pos.dx.clamp(0, _layout.width - _rect.value.width),
+              pos.dy.clamp(0, _layout.height - _rect.value.height),
+              _rect.value.width,
+              _rect.value.height);
           break;
         //CORNERS
         case _CropBoundaries.topLeft:
           final Offset pos = _rect.value.topLeft + delta;
-          _changeRect(
-            top: _preferredCropAspectRatio == null ? pos.dy : pos.dy,
-            left: _preferredCropAspectRatio == null
-                ? pos.dx
-                : pos.dx / _preferredCropAspectRatio!,
-            width: _rect.value.width - delta.dx,
-            height: _preferredCropAspectRatio == null
-                ? _rect.value.height - delta.dy
-                : null,
-          );
+          _changeRect(left: pos.dx, top: pos.dy);
           break;
         case _CropBoundaries.topRight:
-          _changeRect(
-            top: _preferredCropAspectRatio == null
-                ? _rect.value.topRight.dy + delta.dy
-                : (_rect.value.topRight.dy +
-                    (delta.dy * _preferredCropAspectRatio!)),
-            width: _rect.value.width + delta.dx,
-            height: _preferredCropAspectRatio == null
-                ? _rect.value.height - delta.dy
-                : null,
-          );
+          final Offset pos = _rect.value.topRight + delta;
+          _changeRect(right: pos.dx, top: pos.dy);
           break;
         case _CropBoundaries.bottomRight:
-          _changeRect(
-            width: _rect.value.width + delta.dx,
-            height: _rect.value.height + delta.dy,
-          );
+          final Offset pos = _rect.value.bottomRight + delta;
+          _changeRect(right: pos.dx, bottom: pos.dy);
           break;
         case _CropBoundaries.bottomLeft:
-          _changeRect(
-            left: _rect.value.bottomLeft.dx + delta.dx,
-            width: _rect.value.width - delta.dx,
-            height: _rect.value.height + delta.dy,
-          );
+          final Offset pos = _rect.value.bottomLeft + delta;
+          _changeRect(left: pos.dx, bottom: pos.dy);
           break;
         //CENTERS
         case _CropBoundaries.topCenter:
-          _changeRect(
-            top: _rect.value.top + delta.dy,
-            height: _rect.value.height - delta.dy,
-          );
+          _changeRect(top: _rect.value.top + delta.dy);
           break;
         case _CropBoundaries.bottomCenter:
-          _changeRect(height: _rect.value.height + delta.dy);
+          _changeRect(bottom: _rect.value.bottom + delta.dy);
           break;
         case _CropBoundaries.centerLeft:
-          _changeRect(
-            left: _rect.value.left + delta.dx,
-            width: _rect.value.width - delta.dx,
-          );
+          _changeRect(left: _rect.value.left + delta.dx);
           break;
         case _CropBoundaries.centerRight:
-          _changeRect(width: _rect.value.width + delta.dx);
+          _changeRect(right: _rect.value.right + delta.dx);
           break;
         case _CropBoundaries.none:
           break;
@@ -266,44 +294,60 @@ class _CropGridViewerState extends State<CropGridViewer> {
   //-----------//
   //RECT CHANGE//
   //-----------//
-  void _changeRect({double? left, double? top, double? width, double? height}) {
-    top = top ?? _rect.value.top;
-    left = left ?? _rect.value.left;
-    width = width ?? _rect.value.width;
-    height = height ?? _rect.value.height;
 
+  /// Update [Rect] crop from incoming values, while respecting [_preferredCropAspectRatio]
+  void _changeRect({
+    double? left,
+    double? top,
+    double? right,
+    double? bottom,
+  }) {
+    top = (top ?? _rect.value.top).clamp(0, _rect.value.bottom - _margin.dy);
+    left = (left ?? _rect.value.left).clamp(0, _rect.value.right - _margin.dx);
+    right = (right ?? _rect.value.right)
+        .clamp(_rect.value.left + _margin.dx, _layout.width);
+    bottom = (bottom ?? _rect.value.bottom)
+        .clamp(_rect.value.top + _margin.dy, _layout.height);
+
+    // update crop height or width to adjust to the selected aspect ratio
     if (_preferredCropAspectRatio != null) {
-      if (height > width) {
-        height = width / _preferredCropAspectRatio!;
-      } else if (height < width) {
-        width = height / _preferredCropAspectRatio!;
+      final width = right - left;
+      final height = bottom - top;
+
+      if (width / height > _preferredCropAspectRatio!) {
+        switch (_boundary) {
+          case _CropBoundaries.topLeft:
+          case _CropBoundaries.bottomLeft:
+            left = right - height * _preferredCropAspectRatio!;
+            break;
+          case _CropBoundaries.topRight:
+          case _CropBoundaries.bottomRight:
+            right = left + height * _preferredCropAspectRatio!;
+            break;
+          default:
+            assert(false);
+        }
+      } else {
+        switch (_boundary) {
+          case _CropBoundaries.topLeft:
+          case _CropBoundaries.topRight:
+            top = bottom - width / _preferredCropAspectRatio!;
+            break;
+          case _CropBoundaries.bottomLeft:
+          case _CropBoundaries.bottomRight:
+            bottom = top + width / _preferredCropAspectRatio!;
+            break;
+          default:
+            assert(false);
+        }
       }
     }
 
-    final double right = left + width;
-    final double bottom = top + height;
-
-    // TODO : sometimes cannot move the crop because considered as out of bound, but is actually in the middle
-    if (height > _margin.dx && width > _margin.dx) {
-      if (right > _layout.width) width = _rect.value.width;
-
-      _rect.value = Rect.fromLTWH(
-        left >= 0.0
-            ? right <= _layout.width
-                ? left
-                : _rect.value.left
-            : 0.0,
-        top >= 0.0
-            ? bottom <= _layout.height
-                ? top
-                : _rect.value.top
-            : 0.0,
-        width,
-        bottom <= _layout.height ? height : _rect.value.height,
-      );
-    }
+    _rect.value = Rect.fromLTRB(left, top, right, bottom);
   }
 
+  /// Calculate crop [Rect] area
+  /// depending of [_controller] min and max crop values and the size of the layout
   Rect _calculateCropRect([Offset? min, Offset? max]) {
     final Offset minCrop = min ?? _controller.minCrop;
     final Offset maxCrop = max ?? _controller.maxCrop;
@@ -320,12 +364,15 @@ class _CropGridViewerState extends State<CropGridViewer> {
       valueListenable: _transform,
       builder: (_, TransformData transform, __) => Center(
           child: Container(
+              // when widget.showGrid is true, the layout size should never be bigger than the screen size
               constraints: BoxConstraints(
                   maxHeight: ((_controller.rotation == 90 ||
-                          _controller.rotation == 270))
+                              _controller.rotation == 270)) &&
+                          widget.showGrid
                       ? MediaQuery.of(context).size.width -
                           widget.horizontalMargin
                       : Size.infinite.height),
+              // TODO: on rotation 90 or 270 the scale to big so some of the crop area is hidden [#78]
               child: CropTransform(
                   transform: transform,
                   child: VideoViewer(
@@ -336,6 +383,7 @@ class _CropGridViewerState extends State<CropGridViewer> {
                       if (_layout != size) {
                         _layout = size;
                         if (widget.showGrid) {
+                          // need to recompute crop if layout size changed, (i.e after rotation)
                           WidgetsBinding.instance!.addPostFrameCallback((_) {
                             _calculatePreferedCrop();
                           });
@@ -374,6 +422,7 @@ class _CropGridViewerState extends State<CropGridViewer> {
     );
   }
 
+  /// Build [Widget] that hides the cropped area and show the crop grid if widget.showGris is true
   Widget _paint() {
     return ValueListenableBuilder(
       valueListenable: _rect,

--- a/lib/ui/crop/crop_grid.dart
+++ b/lib/ui/crop/crop_grid.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:video_editor/domain/entities/transform_data.dart';
 import 'package:video_editor/ui/crop/crop_grid_painter.dart';
@@ -181,8 +183,6 @@ class _CropGridViewerState extends State<CropGridViewer> {
     // Use margins to increase grabbable areas
     final List<Offset> minMargin = [min - _margin, min + _margin];
     final List<Offset> maxMargin = [max - _margin, max + _margin];
-
-    // TODO : difficult to resize crop area when is on the edges
 
     if (pos >= minMargin[0] && pos <= maxMargin[1]) {
       final Rect topLeft = Rect.fromPoints(minMargin[0], minMargin[1]);
@@ -404,8 +404,8 @@ class _CropGridViewerState extends State<CropGridViewer> {
                                     onPanUpdate: _onPanUpdate,
                                     child: Container(
                                       margin: EdgeInsets.only(
-                                        left: (value.left - _margin.dx).abs(),
-                                        top: (value.top - _margin.dy).abs(),
+                                        left: max(0.0, value.left - _margin.dx),
+                                        top: max(0.0, value.top - _margin.dy),
                                       ),
                                       color: Colors.transparent,
                                       width: value.width + _margin.dx * 2,

--- a/lib/ui/crop/crop_grid.dart
+++ b/lib/ui/crop/crop_grid.dart
@@ -55,6 +55,9 @@ class _CropGridViewerState extends State<CropGridViewer> {
   double? _preferredCropAspectRatio;
   late VideoEditorController _controller;
 
+  /// Minimum size of the cropped area
+  late final double minRectSize = _controller.cropStyle.boundariesLength * 2;
+
   @override
   void initState() {
     _controller = widget.controller;
@@ -293,14 +296,14 @@ class _CropGridViewerState extends State<CropGridViewer> {
 
   /// Update [Rect] crop from incoming values, while respecting [_preferredCropAspectRatio]
   void _changeRect({double? left, double? top, double? right, double? bottom}) {
-    final Rect expandedRect = _expandedRect();
-
-    top = (top ?? _rect.value.top).clamp(0, expandedRect.bottom);
-    left = (left ?? _rect.value.left).clamp(0, expandedRect.right);
-    right =
-        (right ?? _rect.value.right).clamp(expandedRect.left, _layout.width);
-    bottom =
-        (bottom ?? _rect.value.bottom).clamp(expandedRect.top, _layout.height);
+    top = (top ?? _rect.value.top)
+        .clamp(0, max(0.0, _rect.value.bottom - minRectSize));
+    left = (left ?? _rect.value.left)
+        .clamp(0, max(0.0, _rect.value.right - minRectSize));
+    right = (right ?? _rect.value.right)
+        .clamp(_rect.value.left + minRectSize, _layout.width);
+    bottom = (bottom ?? _rect.value.bottom)
+        .clamp(_rect.value.top + minRectSize, _layout.height);
 
     // update crop height or width to adjust to the selected aspect ratio
     if (_preferredCropAspectRatio != null) {

--- a/lib/ui/crop/crop_grid.dart
+++ b/lib/ui/crop/crop_grid.dart
@@ -182,6 +182,8 @@ class _CropGridViewerState extends State<CropGridViewer> {
     final List<Offset> minMargin = [min - _margin, min + _margin];
     final List<Offset> maxMargin = [max - _margin, max + _margin];
 
+    // TODO : difficult to resize crop area when is on the edges
+
     if (pos >= minMargin[0] && pos <= maxMargin[1]) {
       final Rect topLeft = Rect.fromPoints(minMargin[0], minMargin[1]);
       final Rect bottomRight = Rect.fromPoints(maxMargin[0], maxMargin[1]);
@@ -391,52 +393,42 @@ class _CropGridViewerState extends State<CropGridViewer> {
                           _rect.value = _calculateCropRect();
                         }
                       }
-                      return widget.showGrid
-                          ? Stack(children: [
-                              _paint(),
-                              GestureDetector(
-                                onPanEnd: (_) => _onPanEnd(),
-                                onPanStart: _onPanStart,
-                                onPanUpdate: _onPanUpdate,
-                                child: ValueListenableBuilder(
-                                  valueListenable: _rect,
-                                  builder: (_, Rect value, __) {
-                                    final left = value.left - _margin.dx;
-                                    final top = value.top - _margin.dy;
-                                    return Container(
+                      return ValueListenableBuilder(
+                        valueListenable: _rect,
+                        builder: (_, Rect value, __) => widget.showGrid
+                            ? Stack(children: [
+                                _paint(value),
+                                GestureDetector(
+                                    onPanEnd: (_) => _onPanEnd(),
+                                    onPanStart: _onPanStart,
+                                    onPanUpdate: _onPanUpdate,
+                                    child: Container(
                                       margin: EdgeInsets.only(
-                                        left: left < 0.0 ? 0.0 : left,
-                                        top: top < 0.0 ? 0.0 : top,
+                                        left: (value.left - _margin.dx).abs(),
+                                        top: (value.top - _margin.dy).abs(),
                                       ),
                                       color: Colors.transparent,
                                       width: value.width + _margin.dx * 2,
                                       height: value.height + _margin.dy * 2,
-                                    );
-                                  },
-                                ),
-                              ),
-                            ])
-                          : _paint();
+                                    )),
+                              ])
+                            : _paint(value),
+                      );
                     }),
                   )))),
     );
   }
 
   /// Build [Widget] that hides the cropped area and show the crop grid if widget.showGris is true
-  Widget _paint() {
-    return ValueListenableBuilder(
-      valueListenable: _rect,
-      builder: (_, Rect value, __) {
-        return CustomPaint(
-          size: Size.infinite,
-          painter: CropGridPainter(
-            value,
-            style: _controller.cropStyle,
-            showGrid: widget.showGrid,
-            showCenterRects: _controller.preferredCropAspectRatio == null,
-          ),
-        );
-      },
+  Widget _paint(Rect value) {
+    return CustomPaint(
+      size: Size.infinite,
+      painter: CropGridPainter(
+        value,
+        style: _controller.cropStyle,
+        showGrid: widget.showGrid,
+        showCenterRects: _controller.preferredCropAspectRatio == null,
+      ),
     );
   }
 }

--- a/lib/ui/crop/crop_grid_painter.dart
+++ b/lib/ui/crop/crop_grid_painter.dart
@@ -26,27 +26,40 @@ class CropGridPainter extends CustomPainter {
     final Paint paint = Paint()
       ..color = showGrid ? style!.croppingBackground : style!.background;
 
+    double _width = size.width;
+    double _height = size.height;
+    double _bottom = rect.bottom;
+    double _top = rect.top;
+    double _left = rect.left;
+    double _right = rect.right;
+
+    // when scaling, the positions might not be accurates
+    // so add an extra margin to avoid spaces between overlay
+    final _margin = showGrid ? 0.0 : 1.0;
+
     //TOP
     canvas.drawRect(
-      Rect.fromLTWH(0.0, -5.0, size.width, rect.top + 5.0),
+      Rect.fromLTWH(-_margin, -_margin, _width + _margin * 2, _top),
       paint,
     );
     //BOTTOM
     canvas.drawRect(
       Rect.fromPoints(
-        Offset(0.0, rect.bottom),
-        Offset(size.width, size.height + 5.0),
+        Offset(-_margin, _bottom),
+        Offset(_width + _margin, _height + _margin),
       ),
       paint,
     );
     //LEFT
     canvas.drawRect(
-      Rect.fromPoints(Offset(-5.0, rect.topLeft.dy), rect.bottomLeft),
+      Rect.fromPoints(Offset(-_margin, _top - _margin * 2),
+          Offset(_left, _bottom + _margin)),
       paint,
     );
     //RIGHT
     canvas.drawRect(
-      Rect.fromPoints(rect.topRight, Offset(size.width + 5.0, rect.bottom)),
+      Rect.fromPoints(Offset(_right, _top - _margin * 2),
+          Offset(_width + _margin * 2, _bottom + _margin)),
       paint,
     );
   }

--- a/lib/ui/crop/crop_grid_painter.dart
+++ b/lib/ui/crop/crop_grid_painter.dart
@@ -26,40 +26,15 @@ class CropGridPainter extends CustomPainter {
     final Paint paint = Paint()
       ..color = showGrid ? style!.croppingBackground : style!.background;
 
-    double _width = size.width;
-    double _height = size.height;
-    double _bottom = rect.bottom;
-    double _top = rect.top;
-    double _left = rect.left;
-    double _right = rect.right;
-
-    // when scaling, the positions might not be accurates
-    // so add an extra margin to avoid spaces between overlay
-    final _margin = showGrid ? 0.0 : 1.0;
-
-    //TOP
-    canvas.drawRect(
-      Rect.fromLTWH(-_margin, -_margin, _width + _margin * 2, _top),
-      paint,
-    );
-    //BOTTOM
-    canvas.drawRect(
-      Rect.fromPoints(
-        Offset(-_margin, _bottom),
-        Offset(_width + _margin, _height + _margin),
+    // extract [rect] area from the canvas
+    canvas.drawPath(
+      Path.combine(
+        PathOperation.difference,
+        Path()..addRect(Rect.fromLTWH(0, 0, size.width, size.height)),
+        Path()
+          ..addRect(rect)
+          ..close(),
       ),
-      paint,
-    );
-    //LEFT
-    canvas.drawRect(
-      Rect.fromPoints(Offset(-_margin, _top - _margin * 2),
-          Offset(_left, _bottom + _margin)),
-      paint,
-    );
-    //RIGHT
-    canvas.drawRect(
-      Rect.fromPoints(Offset(_right, _top - _margin * 2),
-          Offset(_width + _margin * 2, _bottom + _margin)),
       paint,
     );
   }
@@ -88,72 +63,72 @@ class CropGridPainter extends CustomPainter {
 
   void _drawBoundaries(Canvas canvas, Size size) {
     final double width = style!.boundariesWidth;
-    final double lenght = style!.boundariesLength;
+    final double length = style!.boundariesLength;
     final Paint paint = Paint()..color = style!.boundariesColor;
 
     //----//
     //EDGE//
     //----//
-    //TOP LEFT |-
+    // TOP LEFT |-
     canvas.drawRect(
       Rect.fromPoints(
         rect.topLeft,
-        rect.topLeft + Offset(width, lenght),
+        rect.topLeft + Offset(width, length),
       ),
       paint,
     );
     canvas.drawRect(
       Rect.fromPoints(
-        rect.topLeft + Offset(width, 0.0),
-        rect.topLeft + Offset(lenght, width),
+        rect.topLeft,
+        rect.topLeft + Offset(length, width),
       ),
       paint,
     );
 
-    //TOP RIGHT -|
+    // TOP RIGHT -|
     canvas.drawRect(
       Rect.fromPoints(
-        rect.topRight - Offset(lenght, 0.0),
+        rect.topRight - Offset(length, 0.0),
         rect.topRight + Offset(0.0, width),
       ),
       paint,
     );
     canvas.drawRect(
       Rect.fromPoints(
-        rect.topRight + Offset(0.0, width),
-        rect.topRight - Offset(width, -lenght),
+        rect.topRight,
+        rect.topRight - Offset(width, -length),
       ),
       paint,
     );
 
-    //BOTTOM RIGHT _|
+    // BOTTOM RIGHT _|
     canvas.drawRect(
       Rect.fromPoints(
-        rect.bottomRight - Offset(width, lenght),
+        rect.bottomRight - Offset(width, length),
         rect.bottomRight,
       ),
       paint,
     );
     canvas.drawRect(
       Rect.fromPoints(
-        rect.bottomRight - Offset(width, 0.0),
-        rect.bottomRight - Offset(lenght, width),
+        rect.bottomRight,
+        rect.bottomRight - Offset(length, width),
       ),
       paint,
     );
 
-    //BOTOM LEFT |_
+    // BOTTOM LEFT |_
     canvas.drawRect(
       Rect.fromPoints(
-        rect.bottomLeft - Offset(-width, lenght),
+        rect.bottomLeft - Offset(-width, length),
         rect.bottomLeft,
       ),
       paint,
     );
     canvas.drawRect(
       Rect.fromPoints(
-        rect.bottomLeft - Offset(-width, 0.0),
-        rect.bottomLeft + Offset(lenght, -width),
+        rect.bottomLeft,
+        rect.bottomLeft + Offset(length, -width),
       ),
       paint,
     );
@@ -165,8 +140,8 @@ class CropGridPainter extends CustomPainter {
       //TOPCENTER
       canvas.drawRect(
         Rect.fromPoints(
-          rect.topCenter + Offset(-lenght / 2, 0.0),
-          rect.topCenter + Offset(lenght / 2, width),
+          rect.topCenter + Offset(-length / 2, 0.0),
+          rect.topCenter + Offset(length / 2, width),
         ),
         paint,
       );
@@ -174,8 +149,8 @@ class CropGridPainter extends CustomPainter {
       //BOTTOMCENTER
       canvas.drawRect(
         Rect.fromPoints(
-          rect.bottomCenter + Offset(-lenght / 2, 0.0),
-          rect.bottomCenter + Offset(lenght / 2, -width),
+          rect.bottomCenter + Offset(-length / 2, 0.0),
+          rect.bottomCenter + Offset(length / 2, -width),
         ),
         paint,
       );
@@ -183,8 +158,8 @@ class CropGridPainter extends CustomPainter {
       //CENTERLEFT
       canvas.drawRect(
         Rect.fromPoints(
-          rect.centerLeft + Offset(0.0, -lenght / 2),
-          rect.centerLeft + Offset(width, lenght / 2),
+          rect.centerLeft + Offset(0.0, -length / 2),
+          rect.centerLeft + Offset(width, length / 2),
         ),
         paint,
       );
@@ -192,8 +167,8 @@ class CropGridPainter extends CustomPainter {
       //CENTERRIGHT
       canvas.drawRect(
         Rect.fromPoints(
-          rect.centerRight + Offset(-width, -lenght / 2),
-          rect.centerRight + Offset(0.0, lenght / 2),
+          rect.centerRight + Offset(-width, -length / 2),
+          rect.centerRight + Offset(0.0, length / 2),
         ),
         paint,
       );

--- a/lib/ui/crop/crop_grid_painter.dart
+++ b/lib/ui/crop/crop_grid_painter.dart
@@ -26,11 +26,17 @@ class CropGridPainter extends CustomPainter {
     final Paint paint = Paint()
       ..color = showGrid ? style!.croppingBackground : style!.background;
 
+    // when scaling, the positions might not be exactly accurates
+    // so add an extra margin to be sure to overlay all video
+    final _margin = showGrid ? 0.0 : 1.0;
+
     // extract [rect] area from the canvas
     canvas.drawPath(
       Path.combine(
         PathOperation.difference,
-        Path()..addRect(Rect.fromLTWH(0, 0, size.width, size.height)),
+        Path()
+          ..addRect(Rect.fromLTWH(-_margin, -_margin, size.width + _margin * 2,
+              size.height + _margin * 2)),
         Path()
           ..addRect(rect)
           ..close(),

--- a/lib/ui/trim/thumbnail_slider.dart
+++ b/lib/ui/trim/thumbnail_slider.dart
@@ -36,7 +36,7 @@ class _ThumbnailSliderState extends State<ThumbnailSlider> {
   int _thumbnails = 8;
 
   Size _layout = Size.zero;
-  Stream<List<Uint8List>>? _stream;
+  late final Stream<List<Uint8List>> _stream = (() => _generateThumbnails())();
 
   @override
   void initState() {
@@ -114,7 +114,6 @@ class _ThumbnailSliderState extends State<ThumbnailSlider> {
             ? Size(widget.height * _aspect, widget.height)
             : Size(widget.height, widget.height / _aspect);
         _thumbnails = (_width ~/ _layout.width) + 1;
-        _stream = _generateThumbnails();
         _rect.value = _calculateTrimRect();
       }
 


### PR DESCRIPTION
This PR changes a lot of things in order to fix a lot of bugs:

**List of fixes:**
- When the aspect ratio was updated, the crop area kept getting smaller
- Some corner of the crop was not resizing properly (ie: topRight)
- The crop painter sometimes had spaces between the rects, this should be now definitely fixed using path difference combination
- The edges boundaries of the crop grid had similar problem, the rects overlay each other now



| Before: ratio keep getting smaller + spaces between rect in paint area | With this PR: ratio change depending of size and no more space in paint area |
| --------------------------------------- |  ------------------------------------------ |
|  <video src="https://user-images.githubusercontent.com/22376981/162172791-f60ed2b4-7fb5-42ea-a0d5-4cff9ba378ba.mov" /> |  <video src="https://user-images.githubusercontent.com/22376981/162174290-d351e434-602f-4f64-94ae-92e00481bdd6.mov" /> |