### PR TITLE
Exception in thumbnails generation should not clear the list

### DIFF
--- a/lib/ui/cover/cover_selection.dart
+++ b/lib/ui/cover/cover_selection.dart
@@ -104,15 +104,20 @@ class _CoverSelectionState extends State<CoverSelection>
     final double eachPart = duration / widget.quantity;
     List<CoverData> _byteList = [];
     for (int i = 0; i < widget.quantity; i++) {
-      CoverData _bytes = await widget.controller.generateCoverThumbnail(
-          timeMs: (widget.controller.isTrimmmed
-                  ? (eachPart * i) + widget.controller.startTrim.inMilliseconds
-                  : (eachPart * i))
-              .toInt(),
-          quality: widget.quality);
+      try {
+        final CoverData _bytes = await widget.controller.generateCoverThumbnail(
+            timeMs: (widget.controller.isTrimmmed
+                    ? (eachPart * i) +
+                        widget.controller.startTrim.inMilliseconds
+                    : (eachPart * i))
+                .toInt(),
+            quality: widget.quality);
 
-      if (_bytes.thumbData != null) {
-        _byteList.add(_bytes);
+        if (_bytes.thumbData != null) {
+          _byteList.add(_bytes);
+        }
+      } catch (e) {
+        debugPrint(e.toString());
       }
 
       yield _byteList;

--- a/lib/ui/trim/thumbnail_slider.dart
+++ b/lib/ui/trim/thumbnail_slider.dart
@@ -75,14 +75,18 @@ class _ThumbnailSliderState extends State<ThumbnailSlider> {
     final double eachPart = duration / _thumbnails;
     List<Uint8List> _byteList = [];
     for (int i = 1; i <= _thumbnails; i++) {
-      Uint8List? _bytes = await VideoThumbnail.thumbnailData(
-        imageFormat: ImageFormat.JPEG,
-        video: path,
-        timeMs: (eachPart * i).toInt(),
-        quality: widget.quality,
-      );
-      if (_bytes != null) {
-        _byteList.add(_bytes);
+      try {
+        final Uint8List? _bytes = await VideoThumbnail.thumbnailData(
+          imageFormat: ImageFormat.JPEG,
+          video: path,
+          timeMs: (eachPart * i).toInt(),
+          quality: widget.quality,
+        );
+        if (_bytes != null) {
+          _byteList.add(_bytes);
+        }
+      } catch (e) {
+        debugPrint(e.toString());
       }
 
       yield _byteList;


### PR DESCRIPTION
An exception could occured while generating a thumbnail (cf. https://github.com/justsoft/video_thumbnail/issues/106)

If an exception occurs, the list of thumbnails should not be cleared. Adding a `try/catch` fix this issue.

Could be related to #82.

https://user-images.githubusercontent.com/22376981/163303033-fbf016e0-6ed8-4dba-9605-1e888b501972.mp4

 