### PR TITLE
Allow crop touch detection when out of crop grid view

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,8 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:helpers/helpers.dart'
-    show OpacityTransition, SwipeTransition, AnimatedInteractiveViewer;
+import 'package:helpers/helpers.dart' show OpacityTransition, SwipeTransition;
 import 'package:image_picker/image_picker.dart';
 import 'package:video_editor/video_editor.dart';
 import 'package:video_player/video_player.dart';
@@ -112,6 +111,7 @@ class _VideoEditorState extends State<VideoEditor> {
     // Trim duration will be limited to 30 seconds
     // The cropped area will be initialized to the center of the video with a 9/16 ratio
     _controller = VideoEditorController.file(widget.file,
+        cropStyle: CropGridStyle(selectedBoundariesColor: Colors.redAccent),
         maxDuration: const Duration(seconds: 30))
       ..initialize(aspectRatio: 9 / 16).then((_) => setState(() {}));
     super.initState();
@@ -215,10 +215,7 @@ class _VideoEditorState extends State<VideoEditor> {
                             physics: const NeverScrollableScrollPhysics(),
                             children: [
                               Stack(alignment: Alignment.center, children: [
-                                CropGridViewer(
-                                  controller: _controller,
-                                  showGrid: false,
-                                ),
+                                CropGridViewer.preview(controller: _controller),
                                 AnimatedBuilder(
                                   animation: _controller.video,
                                   builder: (_, __) => OpacityTransition(
@@ -448,7 +445,7 @@ class CropScreen extends StatelessWidget {
       backgroundColor: Colors.black,
       body: SafeArea(
         child: Padding(
-          padding: const EdgeInsets.all(30),
+          padding: const EdgeInsets.symmetric(vertical: 30),
           child: Column(children: [
             Row(children: [
               Expanded(
@@ -468,10 +465,9 @@ class CropScreen extends StatelessWidget {
             ]),
             const SizedBox(height: 15),
             Expanded(
-              child: AnimatedInteractiveViewer(
-                maxScale: 2.4,
-                child: CropGridViewer(
-                    controller: controller, horizontalMargin: 60),
+              child: CropGridViewer.edit(
+                controller: controller,
+                margin: const EdgeInsets.symmetric(horizontal: 20),
               ),
             ),
             const SizedBox(height: 15),

--- a/lib/domain/entities/crop_style.dart
+++ b/lib/domain/entities/crop_style.dart
@@ -9,6 +9,7 @@ class CropGridStyle {
     this.gridLineWidth = 1,
     this.gridSize = 3,
     this.boundariesColor = Colors.white,
+    this.selectedBoundariesColor = Colors.white,
     this.boundariesLength = 20,
     this.boundariesWidth = 5,
   }) : croppingBackground =
@@ -32,6 +33,10 @@ class CropGridStyle {
 
   /// The [boundariesColor] param specifies the color of the crop area's corner
   final Color boundariesColor;
+
+  /// The [boundariesColor] param specifies the color of the crop area's corner
+  /// when is it selected
+  final Color selectedBoundariesColor;
 
   /// The [boundariesLength] param specifies the length of the crop area's corner
   final double boundariesLength;

--- a/lib/domain/helpers.dart
+++ b/lib/domain/helpers.dart
@@ -71,3 +71,11 @@ Rect translateRectIntoBounds(Size layout, Rect rect) {
 /// Return the scale for [rect] to fit [layout]
 double scaleToSize(Size layout, Rect rect) =>
     min(layout.width / rect.width, layout.height / rect.height);
+
+/// Returns `true` if [rect] is left and top are bigger than 0
+/// and if right and bottom are smaller than [size] width and height
+bool isRectContained(Size size, Rect rect) =>
+    rect.left >= 0 &&
+    rect.top >= 0 &&
+    rect.right <= size.width &&
+    rect.bottom <= size.height;

--- a/lib/ui/crop/crop_grid.dart
+++ b/lib/ui/crop/crop_grid.dart
@@ -6,7 +6,8 @@ import 'package:video_editor/domain/bloc/controller.dart';
 import 'package:video_editor/ui/video_viewer.dart';
 import 'package:video_editor/ui/transform.dart';
 
-enum _CropBoundaries {
+@protected
+enum CropBoundaries {
   topLeft,
   topRight,
   bottomLeft,
@@ -50,7 +51,7 @@ class _CropGridViewerState extends State<CropGridViewer> {
 
   Size _viewerSize = Size.zero;
   Size _layout = Size.zero;
-  _CropBoundaries _boundary = _CropBoundaries.none;
+  CropBoundaries _boundary = CropBoundaries.none;
 
   double? _preferredCropAspectRatio;
   late VideoEditorController _controller;
@@ -146,89 +147,89 @@ class _CropGridViewerState extends State<CropGridViewer> {
 
   void _onPanDown(DragDownDetails details) {
     final Offset pos = details.localPosition;
-    _boundary = _CropBoundaries.none;
+    _boundary = CropBoundaries.none;
 
     if (_expandedRect().contains(pos)) {
       if (_rect.value.contains(pos)) {
-        _boundary = _CropBoundaries.inside;
+        _boundary = CropBoundaries.inside;
       }
 
       // CORNERS
       if (_expandedPosition(_rect.value.topLeft).contains(pos)) {
-        _boundary = _CropBoundaries.topLeft;
+        _boundary = CropBoundaries.topLeft;
       } else if (_expandedPosition(_rect.value.topRight).contains(pos)) {
-        _boundary = _CropBoundaries.topRight;
+        _boundary = CropBoundaries.topRight;
       } else if (_expandedPosition(_rect.value.bottomRight).contains(pos)) {
-        _boundary = _CropBoundaries.bottomRight;
+        _boundary = CropBoundaries.bottomRight;
       } else if (_expandedPosition(_rect.value.bottomLeft).contains(pos)) {
-        _boundary = _CropBoundaries.bottomLeft;
+        _boundary = CropBoundaries.bottomLeft;
       } else if (_controller.preferredCropAspectRatio == null) {
         // CENTERS
         if (_expandedPosition(_rect.value.centerLeft).contains(pos)) {
-          _boundary = _CropBoundaries.centerLeft;
+          _boundary = CropBoundaries.centerLeft;
         } else if (_expandedPosition(_rect.value.topCenter).contains(pos)) {
-          _boundary = _CropBoundaries.topCenter;
+          _boundary = CropBoundaries.topCenter;
         } else if (_expandedPosition(_rect.value.centerRight).contains(pos)) {
-          _boundary = _CropBoundaries.centerRight;
+          _boundary = CropBoundaries.centerRight;
         } else if (_expandedPosition(_rect.value.bottomCenter).contains(pos)) {
-          _boundary = _CropBoundaries.bottomCenter;
+          _boundary = CropBoundaries.bottomCenter;
         }
       }
+      setState(() {}); // to update selected boundary color
+      _controller.isCropping = true;
     }
-    _controller.isCropping = true;
   }
 
   void _onPanUpdate(DragUpdateDetails details) {
-    if (_boundary != _CropBoundaries.none) {
-      final Offset delta = details.delta;
+    if (_boundary == CropBoundaries.none) return;
+    final Offset delta = details.delta;
 
-      switch (_boundary) {
-        case _CropBoundaries.inside:
-          final Offset pos = _rect.value.topLeft + delta;
-          _rect.value = Rect.fromLTWH(
-              pos.dx.clamp(0, _layout.width - _rect.value.width),
-              pos.dy.clamp(0, _layout.height - _rect.value.height),
-              _rect.value.width,
-              _rect.value.height);
-          break;
-        //CORNERS
-        case _CropBoundaries.topLeft:
-          final Offset pos = _rect.value.topLeft + delta;
-          _changeRect(left: pos.dx, top: pos.dy);
-          break;
-        case _CropBoundaries.topRight:
-          final Offset pos = _rect.value.topRight + delta;
-          _changeRect(right: pos.dx, top: pos.dy);
-          break;
-        case _CropBoundaries.bottomRight:
-          final Offset pos = _rect.value.bottomRight + delta;
-          _changeRect(right: pos.dx, bottom: pos.dy);
-          break;
-        case _CropBoundaries.bottomLeft:
-          final Offset pos = _rect.value.bottomLeft + delta;
-          _changeRect(left: pos.dx, bottom: pos.dy);
-          break;
-        //CENTERS
-        case _CropBoundaries.topCenter:
-          _changeRect(top: _rect.value.top + delta.dy);
-          break;
-        case _CropBoundaries.bottomCenter:
-          _changeRect(bottom: _rect.value.bottom + delta.dy);
-          break;
-        case _CropBoundaries.centerLeft:
-          _changeRect(left: _rect.value.left + delta.dx);
-          break;
-        case _CropBoundaries.centerRight:
-          _changeRect(right: _rect.value.right + delta.dx);
-          break;
-        case _CropBoundaries.none:
-          break;
-      }
+    switch (_boundary) {
+      case CropBoundaries.inside:
+        final Offset pos = _rect.value.topLeft + delta;
+        _rect.value = Rect.fromLTWH(
+            pos.dx.clamp(0, _layout.width - _rect.value.width),
+            pos.dy.clamp(0, _layout.height - _rect.value.height),
+            _rect.value.width,
+            _rect.value.height);
+        break;
+      //CORNERS
+      case CropBoundaries.topLeft:
+        final Offset pos = _rect.value.topLeft + delta;
+        _changeRect(left: pos.dx, top: pos.dy);
+        break;
+      case CropBoundaries.topRight:
+        final Offset pos = _rect.value.topRight + delta;
+        _changeRect(right: pos.dx, top: pos.dy);
+        break;
+      case CropBoundaries.bottomRight:
+        final Offset pos = _rect.value.bottomRight + delta;
+        _changeRect(right: pos.dx, bottom: pos.dy);
+        break;
+      case CropBoundaries.bottomLeft:
+        final Offset pos = _rect.value.bottomLeft + delta;
+        _changeRect(left: pos.dx, bottom: pos.dy);
+        break;
+      //CENTERS
+      case CropBoundaries.topCenter:
+        _changeRect(top: _rect.value.top + delta.dy);
+        break;
+      case CropBoundaries.bottomCenter:
+        _changeRect(bottom: _rect.value.bottom + delta.dy);
+        break;
+      case CropBoundaries.centerLeft:
+        _changeRect(left: _rect.value.left + delta.dx);
+        break;
+      case CropBoundaries.centerRight:
+        _changeRect(right: _rect.value.right + delta.dx);
+        break;
+      case CropBoundaries.none:
+        break;
     }
   }
 
   void _onPanEnd({bool force = false}) {
-    if (_boundary != _CropBoundaries.none || force) {
+    if (_boundary != CropBoundaries.none || force) {
       final Rect rect = _rect.value;
       _controller.cacheMinCrop = Offset(
         rect.left / _layout.width,
@@ -239,6 +240,8 @@ class _CropGridViewerState extends State<CropGridViewer> {
         rect.bottom / _layout.height,
       );
       _controller.isCropping = false;
+      // to update selected boundary color
+      setState(() => _boundary = CropBoundaries.none);
     }
   }
 
@@ -260,12 +263,12 @@ class _CropGridViewerState extends State<CropGridViewer> {
 
       if (width / height > _preferredCropAspectRatio!) {
         switch (_boundary) {
-          case _CropBoundaries.topLeft:
-          case _CropBoundaries.bottomLeft:
+          case CropBoundaries.topLeft:
+          case CropBoundaries.bottomLeft:
             left = right - height * _preferredCropAspectRatio!;
             break;
-          case _CropBoundaries.topRight:
-          case _CropBoundaries.bottomRight:
+          case CropBoundaries.topRight:
+          case CropBoundaries.bottomRight:
             right = left + height * _preferredCropAspectRatio!;
             break;
           default:
@@ -273,12 +276,12 @@ class _CropGridViewerState extends State<CropGridViewer> {
         }
       } else {
         switch (_boundary) {
-          case _CropBoundaries.topLeft:
-          case _CropBoundaries.topRight:
+          case CropBoundaries.topLeft:
+          case CropBoundaries.topRight:
             top = bottom - width / _preferredCropAspectRatio!;
             break;
-          case _CropBoundaries.bottomLeft:
-          case _CropBoundaries.bottomRight:
+          case CropBoundaries.bottomLeft:
+          case CropBoundaries.bottomRight:
             bottom = top + width / _preferredCropAspectRatio!;
             break;
           default:
@@ -368,6 +371,7 @@ class _CropGridViewerState extends State<CropGridViewer> {
       painter: CropGridPainter(
         value,
         style: _controller.cropStyle,
+        boundary: _boundary,
         showGrid: widget.showGrid,
         showCenterRects: _controller.preferredCropAspectRatio == null,
       ),

--- a/lib/ui/crop/crop_grid_painter.dart
+++ b/lib/ui/crop/crop_grid_painter.dart
@@ -1,16 +1,19 @@
 import 'package:flutter/material.dart';
 import 'package:video_editor/domain/entities/crop_style.dart';
+import 'package:video_editor/ui/crop/crop_grid.dart';
 
 class CropGridPainter extends CustomPainter {
   CropGridPainter(
     this.rect, {
-    this.style,
+    required this.style,
+    this.boundary,
     this.showGrid = false,
     this.showCenterRects = true,
   });
 
   final Rect rect;
-  final CropGridStyle? style;
+  final CropBoundaries? boundary;
+  final CropGridStyle style;
   final bool showGrid, showCenterRects;
 
   @override
@@ -24,7 +27,7 @@ class CropGridPainter extends CustomPainter {
 
   void _drawBackground(Canvas canvas, Size size) {
     final Paint paint = Paint()
-      ..color = showGrid ? style!.croppingBackground : style!.background;
+      ..color = showGrid ? style.croppingBackground : style.background;
 
     // when scaling, the positions might not be exactly accurates
     // so add an extra margin to be sure to overlay all video
@@ -46,10 +49,10 @@ class CropGridPainter extends CustomPainter {
   }
 
   void _drawGrid(Canvas canvas, Size size) {
-    final int gridSize = style!.gridSize;
+    final int gridSize = style.gridSize;
     final Paint paint = Paint()
-      ..strokeWidth = style!.gridLineWidth
-      ..color = style!.gridLineColor;
+      ..strokeWidth = style.gridLineWidth
+      ..color = style.gridLineColor;
 
     for (int i = 1; i < gridSize; i++) {
       double rowDy = rect.topLeft.dy + (rect.height / gridSize) * i;
@@ -67,10 +70,16 @@ class CropGridPainter extends CustomPainter {
     }
   }
 
+  Paint getPaintFromBoundary(CropBoundaries offset) {
+    return Paint()
+      ..color = (boundary == CropBoundaries.inside || offset == boundary)
+          ? style.selectedBoundariesColor
+          : style.boundariesColor;
+  }
+
   void _drawBoundaries(Canvas canvas, Size size) {
-    final double width = style!.boundariesWidth;
-    final double length = style!.boundariesLength;
-    final Paint paint = Paint()..color = style!.boundariesColor;
+    final double width = style.boundariesWidth;
+    final double length = style.boundariesLength;
 
     //----//
     //EDGE//
@@ -81,14 +90,14 @@ class CropGridPainter extends CustomPainter {
         rect.topLeft,
         rect.topLeft + Offset(width, length),
       ),
-      paint,
+      getPaintFromBoundary(CropBoundaries.topLeft),
     );
     canvas.drawRect(
       Rect.fromPoints(
         rect.topLeft,
         rect.topLeft + Offset(length, width),
       ),
-      paint,
+      getPaintFromBoundary(CropBoundaries.topLeft),
     );
 
     // TOP RIGHT -|
@@ -97,14 +106,14 @@ class CropGridPainter extends CustomPainter {
         rect.topRight - Offset(length, 0.0),
         rect.topRight + Offset(0.0, width),
       ),
-      paint,
+      getPaintFromBoundary(CropBoundaries.topRight),
     );
     canvas.drawRect(
       Rect.fromPoints(
         rect.topRight,
         rect.topRight - Offset(width, -length),
       ),
-      paint,
+      getPaintFromBoundary(CropBoundaries.topRight),
     );
 
     // BOTTOM RIGHT _|
@@ -113,14 +122,14 @@ class CropGridPainter extends CustomPainter {
         rect.bottomRight - Offset(width, length),
         rect.bottomRight,
       ),
-      paint,
+      getPaintFromBoundary(CropBoundaries.bottomRight),
     );
     canvas.drawRect(
       Rect.fromPoints(
         rect.bottomRight,
         rect.bottomRight - Offset(length, width),
       ),
-      paint,
+      getPaintFromBoundary(CropBoundaries.bottomRight),
     );
 
     // BOTTOM LEFT |_
@@ -129,14 +138,14 @@ class CropGridPainter extends CustomPainter {
         rect.bottomLeft - Offset(-width, length),
         rect.bottomLeft,
       ),
-      paint,
+      getPaintFromBoundary(CropBoundaries.bottomLeft),
     );
     canvas.drawRect(
       Rect.fromPoints(
         rect.bottomLeft,
         rect.bottomLeft + Offset(length, -width),
       ),
-      paint,
+      getPaintFromBoundary(CropBoundaries.bottomLeft),
     );
 
     //------//
@@ -149,7 +158,7 @@ class CropGridPainter extends CustomPainter {
           rect.topCenter + Offset(-length / 2, 0.0),
           rect.topCenter + Offset(length / 2, width),
         ),
-        paint,
+        getPaintFromBoundary(CropBoundaries.topCenter),
       );
 
       //BOTTOMCENTER
@@ -158,7 +167,7 @@ class CropGridPainter extends CustomPainter {
           rect.bottomCenter + Offset(-length / 2, 0.0),
           rect.bottomCenter + Offset(length / 2, -width),
         ),
-        paint,
+        getPaintFromBoundary(CropBoundaries.bottomCenter),
       );
 
       //CENTERLEFT
@@ -167,7 +176,7 @@ class CropGridPainter extends CustomPainter {
           rect.centerLeft + Offset(0.0, -length / 2),
           rect.centerLeft + Offset(width, length / 2),
         ),
-        paint,
+        getPaintFromBoundary(CropBoundaries.centerLeft),
       );
 
       //CENTERRIGHT
@@ -176,7 +185,7 @@ class CropGridPainter extends CustomPainter {
           rect.centerRight + Offset(-width, -length / 2),
           rect.centerRight + Offset(0.0, length / 2),
         ),
-        paint,
+        getPaintFromBoundary(CropBoundaries.centerRight),
       );
     }
   }


### PR DESCRIPTION
- The crop pan gesture detection is now applied on the size of all the screen which makes it easier to use when touching the crop grid edges
- new `selectedBoundariesColor` style param in CropGridStyle() to change crop boundary color on touch
- new CropGridViewer constructors, CropGridViewer.preview and CropGridViewer.edit
- replaced CropGridViewer `horizontalMargin` parameter by `margin`