### PR TITLE
Better trimmer

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -405,12 +405,19 @@ class _VideoEditorState extends State<VideoEditor> {
 
   Widget _coverSelection() {
     return Container(
-        margin: EdgeInsets.symmetric(horizontal: height / 4),
-        child: CoverSelection(
-          controller: _controller,
-          size: height,
-          quantity: 8,
-        ));
+      margin: EdgeInsets.symmetric(horizontal: height / 4),
+      child: CoverSelection(
+        controller: _controller,
+        size: height,
+        quantity: 8,
+        selectedCoverBuilder: (cover, size) {
+          return Stack(
+            alignment: Alignment.center,
+            children: [cover, const Icon(Icons.check_circle)],
+          );
+        },
+      ),
+    );
   }
 
   Widget _customSnackBar() {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -405,7 +405,7 @@ class _VideoEditorState extends State<VideoEditor> {
         margin: EdgeInsets.symmetric(horizontal: height / 4),
         child: CoverSelection(
           controller: _controller,
-          height: height,
+          size: height,
           quantity: 8,
         ));
   }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -269,15 +269,15 @@ class _VideoEditorState extends State<VideoEditor> {
                                 ),
                                 Expanded(
                                   child: TabBarView(
+                                    physics:
+                                        const NeverScrollableScrollPhysics(),
                                     children: [
                                       Column(
-                                          mainAxisAlignment:
-                                              MainAxisAlignment.center,
-                                          children: _trimSlider()),
-                                      Column(
-                                          mainAxisAlignment:
-                                              MainAxisAlignment.center,
-                                          children: [_coverSelection()]),
+                                        mainAxisAlignment:
+                                            MainAxisAlignment.center,
+                                        children: _trimSlider(),
+                                      ),
+                                      _coverSelection(),
                                     ],
                                   ),
                                 )
@@ -404,18 +404,28 @@ class _VideoEditorState extends State<VideoEditor> {
   }
 
   Widget _coverSelection() {
-    return Container(
-      margin: EdgeInsets.symmetric(horizontal: height / 4),
-      child: CoverSelection(
-        controller: _controller,
-        size: height,
-        quantity: 8,
-        selectedCoverBuilder: (cover, size) {
-          return Stack(
-            alignment: Alignment.center,
-            children: [cover, const Icon(Icons.check_circle)],
-          );
-        },
+    return SingleChildScrollView(
+      child: Center(
+        child: Container(
+          margin: const EdgeInsets.all(15),
+          child: CoverSelection(
+            controller: _controller,
+            size: height + 10,
+            quantity: 8,
+            selectedCoverBuilder: (cover, size) {
+              return Stack(
+                alignment: Alignment.center,
+                children: [
+                  cover,
+                  Icon(
+                    Icons.check_circle,
+                    color: const CoverSelectionStyle().selectedBorderColor,
+                  )
+                ],
+              );
+            },
+          ),
+        ),
       ),
     );
   }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -362,9 +362,12 @@ class _VideoEditorState extends State<VideoEditor> {
   List<Widget> _trimSlider() {
     return [
       AnimatedBuilder(
-        animation: _controller.video,
+        animation: Listenable.merge([
+          _controller,
+          _controller.video,
+        ]),
         builder: (_, __) {
-          final duration = _controller.video.value.duration.inSeconds;
+          final duration = _controller.videoDuration.inSeconds;
           final pos = _controller.trimPosition * duration;
           final start = _controller.minTrim * duration;
           final end = _controller.maxTrim * duration;
@@ -381,7 +384,7 @@ class _VideoEditorState extends State<VideoEditor> {
                   const SizedBox(width: 10),
                   Text(formatter(Duration(seconds: end.toInt()))),
                 ]),
-              )
+              ),
             ]),
           );
         },

--- a/lib/domain/bloc/controller.dart
+++ b/lib/domain/bloc/controller.dart
@@ -75,8 +75,8 @@ class VideoEditorController extends ChangeNotifier {
           Platform.isIOS ? Uri.encodeFull(file.path) : file.path,
         )),
         _maxDuration = maxDuration ?? Duration.zero,
-        cropStyle = cropStyle ?? CropGridStyle(),
-        coverStyle = coverStyle ?? CoverSelectionStyle(),
+        cropStyle = cropStyle ?? const CropGridStyle(),
+        coverStyle = coverStyle ?? const CoverSelectionStyle(),
         trimStyle = trimStyle ?? TrimSliderStyle();
 
   int _rotation = 0;

--- a/lib/domain/bloc/controller.dart
+++ b/lib/domain/bloc/controller.dart
@@ -259,6 +259,7 @@ class VideoEditorController extends ChangeNotifier {
     final executions = await FFmpegKit.listSessions();
     if (executions.isNotEmpty) await FFmpegKit.cancel();
     _video.dispose();
+    _selectedCover.dispose();
     super.dispose();
   }
 
@@ -416,6 +417,8 @@ class VideoEditorController extends ChangeNotifier {
     }
     notifyListeners();
   }
+
+  bool get isRotated => rotation == 90 || rotation == 270;
 
   /// Convert the [_rotation] value into a [String]
   /// used to provide crop values to Ffmpeg ([see more](https://ffmpeg.org/ffmpeg-filters.html#transpose-1))

--- a/lib/domain/bloc/controller.dart
+++ b/lib/domain/bloc/controller.dart
@@ -265,7 +265,7 @@ class VideoEditorController extends ChangeNotifier {
 
   void _videoListener() {
     final position = videoPosition;
-    if (position < _trimStart || position >= _trimEnd) {
+    if (position < _trimStart || position > _trimEnd) {
       _video.seekTo(_trimStart);
     }
   }

--- a/lib/domain/bloc/controller.dart
+++ b/lib/domain/bloc/controller.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'dart:typed_data';
 import 'package:ffmpeg_kit_flutter_min_gpl/ffmpeg_kit.dart';
 import 'package:ffmpeg_kit_flutter_min_gpl/ffmpeg_kit_config.dart';
 import 'package:ffmpeg_kit_flutter_min_gpl/ffprobe_kit.dart';
@@ -8,6 +7,7 @@ import 'package:ffmpeg_kit_flutter_min_gpl/statistics.dart';
 import 'package:path/path.dart' as path;
 import 'package:flutter/material.dart';
 import 'package:video_editor/domain/helpers.dart';
+import 'package:video_editor/domain/thumbnails.dart';
 import 'package:video_player/video_player.dart';
 import 'package:path_provider/path_provider.dart';
 
@@ -373,24 +373,11 @@ class VideoEditorController extends ChangeNotifier {
 
   /// Generate cover at [startTrim] time in milliseconds
   void generateDefaultCoverThumbnail() async {
-    final defaultCover =
-        await generateCoverThumbnail(timeMs: startTrim.inMilliseconds);
-    updateSelectedCover(defaultCover);
-  }
-
-  /// Generate a cover at [timeMs] in video
-  ///
-  /// return [CoverData] depending on [timeMs] milliseconds
-  Future<CoverData> generateCoverThumbnail(
-      {int timeMs = 0, int quality = 10}) async {
-    final Uint8List? thumbData = await VideoThumbnail.thumbnailData(
-      imageFormat: ImageFormat.JPEG,
-      video: file.path,
-      timeMs: timeMs,
-      quality: quality,
+    final defaultCover = await generateSingleCoverThumbnail(
+      file.path,
+      timeMs: startTrim.inMilliseconds,
     );
-
-    return CoverData(thumbData: thumbData, timeMs: timeMs);
+    updateSelectedCover(defaultCover);
   }
 
   /// Get the [selectedCover] notifier

--- a/lib/domain/bloc/controller.dart
+++ b/lib/domain/bloc/controller.dart
@@ -330,7 +330,7 @@ class VideoEditorController extends ChangeNotifier {
   /// Get the [isTrimmed]
   ///
   /// `true` if the trimmed value has beem changed
-  bool get isTrimmmed => _isTrimmed;
+  bool get isTrimmed => _isTrimmed;
 
   /// Get the [isTrimming]
   ///

--- a/lib/domain/entities/cover_data.dart
+++ b/lib/domain/entities/cover_data.dart
@@ -1,7 +1,7 @@
 import 'dart:typed_data';
 
 class CoverData {
-  CoverData({
+  const CoverData({
     this.thumbData,
     required this.timeMs,
   });

--- a/lib/domain/entities/cover_style.dart
+++ b/lib/domain/entities/cover_style.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 
 class CoverSelectionStyle {
   /// Style for [CoverSelection]. It's use on VideoEditorController
-  CoverSelectionStyle({
+  const CoverSelectionStyle({
     this.selectedBorderColor = Colors.white,
     this.borderWidth = 2,
     this.borderRadius = 5.0,

--- a/lib/domain/entities/cover_style.dart
+++ b/lib/domain/entities/cover_style.dart
@@ -20,6 +20,6 @@ class CoverSelectionStyle {
 
   /// The [borderRadius] param specifies the border radius of each cover thumbnail
   ///
-  /// Defaults to `0`
+  /// Defaults to `5`
   final double borderRadius;
 }

--- a/lib/domain/entities/cover_style.dart
+++ b/lib/domain/entities/cover_style.dart
@@ -10,7 +10,7 @@ class CoverSelectionStyle {
 
   /// The [selectedBorderColor] param specifies the color of the border around the selected cover thumbnail
   ///
-  /// Defaults to `Colors.white`
+  /// Defaults to [Colors.white]
   final Color selectedBorderColor;
 
   /// The [borderWidth] param specifies the width of the border around each cover thumbnails

--- a/lib/domain/entities/cover_style.dart
+++ b/lib/domain/entities/cover_style.dart
@@ -1,24 +1,25 @@
 import 'package:flutter/material.dart';
 
 class CoverSelectionStyle {
-  ///Style for [CoverSelection]. It's use on VideoEditorController
+  /// Style for [CoverSelection]. It's use on VideoEditorController
   CoverSelectionStyle({
-    Color? selectedBorderColor,
-    this.selectedBorderWidth = 2,
-    this.selectedIndicator,
-    this.selectedIndicatorAlign = Alignment.bottomRight,
-  }) : selectedBorderColor = selectedBorderColor ?? Colors.white;
+    this.selectedBorderColor = Colors.white,
+    this.borderWidth = 2,
+    this.borderRadius = 5.0,
+  });
 
   /// The [selectedBorderColor] param specifies the color of the border around the selected cover thumbnail
-  /// The default value of this property is `Colors.white`
+  ///
+  /// Defaults to `Colors.white`
   final Color selectedBorderColor;
 
-  /// The [selectedBorderWidth] param specifies the width of the border around the selected cover thumbnail
-  final double selectedBorderWidth;
+  /// The [borderWidth] param specifies the width of the border around each cover thumbnails
+  ///
+  /// Defaults to `2`
+  final double borderWidth;
 
-  /// The [selectedIndicator] param specifies the [Widget] to show on top of the selected cover
-  final Widget? selectedIndicator;
-
-  /// The [selectedIndicatorAlign] param specifies where [selectedIndicator] should be shown in the [Stack]
-  final AlignmentGeometry selectedIndicatorAlign;
+  /// The [borderRadius] param specifies the border radius of each cover thumbnail
+  ///
+  /// Defaults to `0`
+  final double borderRadius;
 }

--- a/lib/domain/entities/crop_style.dart
+++ b/lib/domain/entities/crop_style.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 
 class CropGridStyle {
   ///Style for [CropGridViewer]. It's use on VideoEditorController
-  CropGridStyle({
+  const CropGridStyle({
     this.croppingBackground = Colors.black45,
     this.background = Colors.black,
     this.gridLineColor = Colors.white,

--- a/lib/domain/entities/crop_style.dart
+++ b/lib/domain/entities/crop_style.dart
@@ -15,27 +15,42 @@ class CropGridStyle {
             croppingBackground ?? Colors.black.withOpacity(0.48);
 
   /// The [croppingBackground] param specifies the color of the paint area outside the crop area when copping
-  /// The default value of this property is `Colors.black.withOpacity(0.48)`
+  ///
+  /// Defaults to `Colors.black.withOpacity(0.48)`
   final Color croppingBackground;
 
   /// The [background] param specifies the color of the paint area outside the crop area when not copping
+  ///
+  /// Defaults to [Colors.black]
   final Color background;
 
   /// The [gridLineWidth] param specifies the width of the crop lines
+  ///
+  /// Defaults to `1`
   final double gridLineWidth;
 
   /// The [gridLineColor] param specifies the color of the crop lines
+  ///
+  /// Defaults to [Colors.white]
   final Color gridLineColor;
 
   /// The [gridSize] param specifies the quantity of columns and rows in the crop view
+  ///
+  /// Defaults to `3`
   final int gridSize;
 
   /// The [boundariesColor] param specifies the color of the crop area's corner
+  ///
+  /// Defaults to [Colors.white]
   final Color boundariesColor;
 
   /// The [boundariesLength] param specifies the length of the crop area's corner
+  ///
+  /// Defaults to `20`
   final double boundariesLength;
 
   /// The [boundariesWidth] param specifies the width of the crop area's corner
+  ///
+  /// Defaults to `5`
   final double boundariesWidth;
 }

--- a/lib/domain/entities/crop_style.dart
+++ b/lib/domain/entities/crop_style.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 class CropGridStyle {
   ///Style for [CropGridViewer]. It's use on VideoEditorController
   CropGridStyle({
-    Color? croppingBackground,
+    this.croppingBackground = Colors.black45,
     this.background = Colors.black,
     this.gridLineColor = Colors.white,
     this.gridLineWidth = 1,
@@ -11,12 +11,11 @@ class CropGridStyle {
     this.boundariesColor = Colors.white,
     this.boundariesLength = 20,
     this.boundariesWidth = 5,
-  }) : croppingBackground =
-            croppingBackground ?? Colors.black.withOpacity(0.48);
+  });
 
   /// The [croppingBackground] param specifies the color of the paint area outside the crop area when copping
   ///
-  /// Defaults to `Colors.black.withOpacity(0.48)`
+  /// Defaults to [Colors.black45]
   final Color croppingBackground;
 
   /// The [background] param specifies the color of the paint area outside the crop area when not copping

--- a/lib/domain/entities/transform_data.dart
+++ b/lib/domain/entities/transform_data.dart
@@ -20,14 +20,16 @@ class TransformData {
     Size layout,
     // the maximum size to display
     Size maxSize,
-    VideoEditorController controller,
+    // if controller is not provided, rotation is set to default (0)
+    VideoEditorController? controller,
   ) {
-    if (controller.rotation == 90 || controller.rotation == 270) {
+    if (controller != null &&
+        (controller.rotation == 90 || controller.rotation == 270)) {
       maxSize = maxSize.flipped;
     }
 
     final double scale = scaleToSize(maxSize, rect);
-    final double rotation = -controller.rotation * (pi / 180.0);
+    final double rotation = -(controller?.rotation ?? 0) * (pi / 180.0);
     final Offset translate = Offset(
       ((layout.width - rect.width) / 2) - rect.left,
       ((layout.height - rect.height) / 2) - rect.top,
@@ -40,9 +42,7 @@ class TransformData {
     );
   }
 
-  factory TransformData.fromController(
-    VideoEditorController controller,
-  ) {
+  factory TransformData.fromController(VideoEditorController controller) {
     return TransformData(
       rotation: -controller.rotation * (pi / 180.0),
       scale: 1.0,

--- a/lib/domain/entities/transform_data.dart
+++ b/lib/domain/entities/transform_data.dart
@@ -13,6 +13,17 @@ class TransformData {
   final double rotation, scale;
   final Offset translate;
 
+  TransformData copyWith({
+    double? scale,
+    double? rotation,
+    Offset? translate,
+  }) =>
+      TransformData(
+        scale: scale ?? this.scale,
+        rotation: rotation ?? this.rotation,
+        translate: translate ?? this.translate,
+      );
+
   factory TransformData.fromRect(
     // the selected crop rect area
     Rect rect,
@@ -23,8 +34,7 @@ class TransformData {
     // if controller is not provided, rotation is set to default (0)
     VideoEditorController? controller,
   ) {
-    if (controller != null &&
-        (controller.rotation == 90 || controller.rotation == 270)) {
+    if (controller != null && controller.isRotated) {
       maxSize = maxSize.flipped;
     }
 

--- a/lib/domain/entities/transform_data.dart
+++ b/lib/domain/entities/transform_data.dart
@@ -5,7 +5,7 @@ import 'package:video_editor/domain/bloc/controller.dart';
 import 'package:video_editor/domain/helpers.dart';
 
 class TransformData {
-  TransformData({
+  const TransformData({
     this.scale = 1.0,
     this.rotation = 0.0,
     this.translate = Offset.zero,

--- a/lib/domain/entities/trim_style.dart
+++ b/lib/domain/entities/trim_style.dart
@@ -1,48 +1,91 @@
 import 'package:flutter/material.dart';
 
+enum TrimSliderEdgesType { bar, circle }
+
 class TrimSliderStyle {
   ///Style for [TrimSlider]. It's use on VideoEditorController
   TrimSliderStyle({
     Color? background,
-    this.positionLineColor = Colors.red,
-    this.positionLineWidth = 2,
+    this.positionLineColor = Colors.white,
+    this.positionLineWidth = 4,
     this.lineColor = Colors.white,
+    this.onTrimmingColor = const Color(0xffffcc00),
     this.lineWidth = 2,
+    // edges
+    this.edgesType = TrimSliderEdgesType.bar,
+    double? edgesSize,
+    // icons
     this.iconColor = Colors.black,
-    this.circleSize = 8,
     this.iconSize = 25,
     this.leftIcon = Icons.arrow_left,
     this.rightIcon = Icons.arrow_right,
-  }) : background = background ?? Colors.black.withOpacity(0.6);
+  })  : background = background ?? Colors.black.withOpacity(0.6),
+        edgesSize =
+            edgesSize ?? (edgesType == TrimSliderEdgesType.bar ? 10 : 8);
 
   /// The [background] param specifies the color of the paint area outside the trimmed area
-  /// The default value of this property `Colors.black.withOpacity(0.6)
+  ///
+  /// Defaults to `Colors.black.withOpacity(0.6)`
   final Color background;
 
   /// The [positionLineColor] param specifies the color of the line showing the video position
+  ///
+  /// Defaults to [Colors.white]
   final Color positionLineColor;
 
   /// The [positionLineWidth] param specifies the width  of the line showing the video position
+  ///
+  /// Defaults to `4`
   final double positionLineWidth;
 
   /// The [lineColor] param specifies the color of the borders around the trimmed area
+  ///
+  /// Defaults to [Colors.white]
   final Color lineColor;
 
+  /// The [onTrimmingColor] param specifies the color of the borders around the trimmed area while it is getting trimmed
+  ///
+  /// Defaults to `Color(0xffffcc00)`
+  final Color onTrimmingColor;
+
   /// The [lineWidth] param specifies the width of the borders around the trimmed area
+  ///
+  /// Defaults to `2`
   final double lineWidth;
 
+  /// The [edgesType] param specifies the style to apply to the edges (left & right) of the trimmer
+  ///
+  /// Defaults to [TrimSliderEdgesType.bar]
+  final TrimSliderEdgesType edgesType;
+
+  /// The [edgesSize] param specifies the size of the edges behind the icons
+  /// used only if [edgesType] equals [TrimSliderEdgesType.circle]
+  ///
+  /// If [edgesType] equals [TrimSliderEdgesType.bar] defaults to `10`
+  /// If [edgesType] equals [TrimSliderEdgesType.circle] defaults to `8`
+  final double edgesSize;
+
   /// The [iconColor] param specifies the color of the icons on the trimmed area's edges
+  ///
+  /// Defaults to [Colors.black]
   final Color iconColor;
 
-  /// The [circleSize] param specifies the size of the circle behind the icons on the trimmed area's edges
-  final double circleSize;
-
   /// The [iconSize] param specifies the size of the icon on the trimmed area's edges
+  ///
+  /// Defaults to `25`
   final double iconSize;
 
   /// The [leftIcon] param specifies the icon to show on the left edge of the trimmed area
+  ///
+  /// Defaults to [Icons.arrow_left]
   final IconData? leftIcon;
 
   /// The [rightIcon] param specifies the icon to show on the right edge of the trimmed area
+  ///
+  /// Defaults to [Icons.arrow_right]
   final IconData? rightIcon;
+
+  /// Returns left and right line width depending on [edgesType]
+  double get edgeWidth =>
+      edgesType == TrimSliderEdgesType.bar ? edgesSize : lineWidth;
 }

--- a/lib/domain/entities/trim_style.dart
+++ b/lib/domain/entities/trim_style.dart
@@ -4,7 +4,7 @@ enum TrimSliderEdgesType { bar, circle }
 
 class TrimSliderStyle {
   ///Style for [TrimSlider]. It's use on VideoEditorController
-  TrimSliderStyle({
+  const TrimSliderStyle({
     this.background = Colors.black54,
     this.positionLineColor = Colors.white,
     this.positionLineWidth = 4,

--- a/lib/domain/entities/trim_style.dart
+++ b/lib/domain/entities/trim_style.dart
@@ -10,6 +10,7 @@ class TrimSliderStyle {
     this.positionLineWidth = 4,
     this.lineColor = Colors.white70,
     this.onTrimmingColor = const Color(0xffffcc00),
+    this.onTrimmedColor = const Color(0xffffcc00),
     this.lineWidth = 2,
     this.borderRadius = 5.0,
     // edges
@@ -46,6 +47,11 @@ class TrimSliderStyle {
   ///
   /// Defaults to `Color(0xffffcc00)`
   final Color onTrimmingColor;
+
+  /// The [onTrimmedColor] param specifies the color of the borders around the trimmed area when the trimmed parameters are not default values
+  ///
+  /// Defaults to `Color(0xffffcc00)`
+  final Color onTrimmedColor;
 
   /// The [lineWidth] param specifies the width of the borders around the trimmed area
   ///

--- a/lib/domain/entities/trim_style.dart
+++ b/lib/domain/entities/trim_style.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:video_editor/domain/helpers.dart';
 
 enum TrimSliderEdgesType { bar, circle }
 
@@ -8,9 +9,9 @@ class TrimSliderStyle {
     this.background = Colors.black54,
     this.positionLineColor = Colors.white,
     this.positionLineWidth = 4,
-    this.lineColor = Colors.white70,
-    this.onTrimmingColor = const Color(0xffffcc00),
-    this.onTrimmedColor = const Color(0xffffcc00),
+    this.lineColor = Colors.white60,
+    this.onTrimmingColor = kDefaultSelectedColor,
+    this.onTrimmedColor = kDefaultSelectedColor,
     this.lineWidth = 2,
     this.borderRadius = 5.0,
     // edges
@@ -45,12 +46,12 @@ class TrimSliderStyle {
 
   /// The [onTrimmingColor] param specifies the color of the borders around the trimmed area while it is getting trimmed
   ///
-  /// Defaults to `Color(0xffffcc00)`
+  /// Defaults to [kDefaultSelectedColor]
   final Color onTrimmingColor;
 
   /// The [onTrimmedColor] param specifies the color of the borders around the trimmed area when the trimmed parameters are not default values
   ///
-  /// Defaults to `Color(0xffffcc00)`
+  /// Defaults to [kDefaultSelectedColor]
   final Color onTrimmedColor;
 
   /// The [lineWidth] param specifies the width of the borders around the trimmed area

--- a/lib/domain/entities/trim_style.dart
+++ b/lib/domain/entities/trim_style.dart
@@ -5,10 +5,10 @@ enum TrimSliderEdgesType { bar, circle }
 class TrimSliderStyle {
   ///Style for [TrimSlider]. It's use on VideoEditorController
   TrimSliderStyle({
-    Color? background,
+    this.background = Colors.black54,
     this.positionLineColor = Colors.white,
     this.positionLineWidth = 4,
-    this.lineColor = Colors.white,
+    this.lineColor = Colors.white70,
     this.onTrimmingColor = const Color(0xffffcc00),
     this.lineWidth = 2,
     this.borderRadius = 5.0,
@@ -17,16 +17,14 @@ class TrimSliderStyle {
     double? edgesSize,
     // icons
     this.iconColor = Colors.black,
-    this.iconSize = 25,
-    this.leftIcon = Icons.arrow_left,
-    this.rightIcon = Icons.arrow_right,
-  })  : background = background ?? Colors.black.withOpacity(0.6),
-        edgesSize =
-            edgesSize ?? (edgesType == TrimSliderEdgesType.bar ? 10 : 8);
+    this.iconSize = 16,
+    this.leftIcon = Icons.arrow_back_ios_rounded,
+    this.rightIcon = Icons.arrow_forward_ios_rounded,
+  }) : edgesSize = edgesSize ?? (edgesType == TrimSliderEdgesType.bar ? 10 : 8);
 
   /// The [background] param specifies the color of the paint area outside the trimmed area
   ///
-  /// Defaults to `Colors.black.withOpacity(0.6)`
+  /// Defaults to [Colors.black54]
   final Color background;
 
   /// The [positionLineColor] param specifies the color of the line showing the video position
@@ -41,7 +39,7 @@ class TrimSliderStyle {
 
   /// The [lineColor] param specifies the color of the borders around the trimmed area
   ///
-  /// Defaults to [Colors.white]
+  /// Defaults to [Colors.white70]
   final Color lineColor;
 
   /// The [onTrimmingColor] param specifies the color of the borders around the trimmed area while it is getting trimmed
@@ -78,17 +76,17 @@ class TrimSliderStyle {
 
   /// The [iconSize] param specifies the size of the icon on the trimmed area's edges
   ///
-  /// Defaults to `25`
+  /// Defaults to `16`
   final double iconSize;
 
   /// The [leftIcon] param specifies the icon to show on the left edge of the trimmed area
   ///
-  /// Defaults to [Icons.arrow_left]
+  /// Defaults to [Icons.arrow_back_ios_rounded]
   final IconData? leftIcon;
 
   /// The [rightIcon] param specifies the icon to show on the right edge of the trimmed area
   ///
-  /// Defaults to [Icons.arrow_right]
+  /// Defaults to [Icons.arrow_forward_ios_rounded]
   final IconData? rightIcon;
 
   /// Returns left and right line width depending on [edgesType]

--- a/lib/domain/entities/trim_style.dart
+++ b/lib/domain/entities/trim_style.dart
@@ -11,6 +11,7 @@ class TrimSliderStyle {
     this.lineColor = Colors.white,
     this.onTrimmingColor = const Color(0xffffcc00),
     this.lineWidth = 2,
+    this.borderRadius = 5.0,
     // edges
     this.edgesType = TrimSliderEdgesType.bar,
     double? edgesSize,
@@ -52,6 +53,11 @@ class TrimSliderStyle {
   ///
   /// Defaults to `2`
   final double lineWidth;
+
+  /// The [borderRadius] param specifies the border radius around the trimmer
+  ///
+  /// Defaults to `5`
+  final double borderRadius;
 
   /// The [edgesType] param specifies the style to apply to the edges (left & right) of the trimmer
   ///

--- a/lib/domain/helpers.dart
+++ b/lib/domain/helpers.dart
@@ -105,10 +105,10 @@ bool isNumberAlmost(double a, int b) => nearEqual(a, b.toDouble(), 0.01);
 ///
 /// ```
 /// i.e = max=4, length=11
-/// index=0 => = 0
-/// index=1 => = 3
-/// index=2 => = 6
-/// index=3 => = 9
+/// index=0 => 1
+/// index=1 => 4
+/// index=2 => 7
+/// index=3 => 9
 /// ```
 int getBestIndex(int max, int length, int index) =>
-    max >= length || max == 0 ? index : (index * (length / max).round());
+    max >= length || max == 0 ? index : 1 + (index * (length / max)).round();

--- a/lib/domain/helpers.dart
+++ b/lib/domain/helpers.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/physics.dart';
 import 'package:video_editor/video_editor.dart';
 
 /// Returns a desired dimension of [layout] that respect [r] aspect ratio
@@ -95,4 +96,4 @@ Rect calculateCroppedRect(
 }
 
 /// Return `true` if the difference between [a] and [b] is less than `0.001`
-bool isNumberAlmost(double a, int b) => a.abs() - b < 0.001;
+bool isNumberAlmost(double a, int b) => nearEqual(a, b.toDouble(), 0.01);

--- a/lib/domain/helpers.dart
+++ b/lib/domain/helpers.dart
@@ -4,6 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/physics.dart';
 import 'package:video_editor/video_editor.dart';
 
+const kDefaultSelectedColor = Color(0xffffcc00);
+
 /// Returns a desired dimension of [layout] that respect [r] aspect ratio
 Size computeSizeWithRatio(Size layout, double r) {
   if (layout.aspectRatio == r) {

--- a/lib/domain/helpers.dart
+++ b/lib/domain/helpers.dart
@@ -97,3 +97,16 @@ Rect calculateCroppedRect(
 
 /// Return `true` if the difference between [a] and [b] is less than `0.001`
 bool isNumberAlmost(double a, int b) => nearEqual(a, b.toDouble(), 0.01);
+
+/// Return the best index to spread among the list [length] when limited to a [max] value
+/// When [max] is 0 or smaller than [length], returns [index]
+///
+/// ```
+/// i.e = max=4, length=11
+/// index=0 => = 0
+/// index=1 => = 3
+/// index=2 => = 6
+/// index=3 => = 9
+/// ```
+int getBestIndex(int max, int length, int index) =>
+    max >= length || max == 0 ? index : (index * (length / max).round());

--- a/lib/domain/helpers.dart
+++ b/lib/domain/helpers.dart
@@ -73,6 +73,10 @@ Rect translateRectIntoBounds(Size layout, Rect rect) {
 double scaleToSize(Size layout, Rect rect) =>
     min(layout.width / rect.width, layout.height / rect.height);
 
+/// Return the scale for [rect] to not be smaller [layout]
+double scaleToSizeMax(Size layout, Rect rect) =>
+    max(layout.width / rect.width, layout.height / rect.height);
+
 /// Calculate crop [Rect] area
 /// depending of [controller] min and max crop values and the size of the layout
 Rect calculateCroppedRect(
@@ -89,3 +93,6 @@ Rect calculateCroppedRect(
     Offset(maxCrop.dx * layout.width, maxCrop.dy * layout.height),
   );
 }
+
+/// Return `true` if the difference between [a] and [b] is less than `0.001`
+bool isNumberAlmost(double a, int b) => a.abs() - b < 0.001;

--- a/lib/domain/helpers.dart
+++ b/lib/domain/helpers.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
+import 'package:video_editor/video_editor.dart';
 
 /// Returns a desired dimension of [layout] that respect [r] aspect ratio
 Size computeSizeWithRatio(Size layout, double r) {
@@ -71,3 +72,20 @@ Rect translateRectIntoBounds(Size layout, Rect rect) {
 /// Return the scale for [rect] to fit [layout]
 double scaleToSize(Size layout, Rect rect) =>
     min(layout.width / rect.width, layout.height / rect.height);
+
+/// Calculate crop [Rect] area
+/// depending of [controller] min and max crop values and the size of the layout
+Rect calculateCroppedRect(
+  VideoEditorController controller,
+  Size layout, {
+  Offset? min,
+  Offset? max,
+}) {
+  final Offset minCrop = min ?? controller.minCrop;
+  final Offset maxCrop = max ?? controller.maxCrop;
+
+  return Rect.fromPoints(
+    Offset(minCrop.dx * layout.width, minCrop.dy * layout.height),
+    Offset(maxCrop.dx * layout.width, maxCrop.dy * layout.height),
+  );
+}

--- a/lib/domain/thumbnails.dart
+++ b/lib/domain/thumbnails.dart
@@ -1,0 +1,85 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:video_editor/domain/bloc/controller.dart';
+import 'package:video_editor/domain/entities/cover_data.dart';
+import 'package:video_thumbnail/video_thumbnail.dart';
+
+Stream<List<Uint8List>> generateTrimThumbnails(
+  VideoEditorController controller, {
+  required int quantity,
+  int quality = 10,
+}) async* {
+  final String path = controller.file.path;
+  final double eachPart = controller.videoDuration.inMilliseconds / quantity;
+  List<Uint8List> byteList = [];
+
+  for (int i = 1; i <= quantity; i++) {
+    try {
+      final Uint8List? bytes = await VideoThumbnail.thumbnailData(
+        imageFormat: ImageFormat.JPEG,
+        video: path,
+        timeMs: (eachPart * i).toInt(),
+        quality: quality,
+      );
+      if (bytes != null) {
+        byteList.add(bytes);
+      }
+    } catch (e) {
+      debugPrint(e.toString());
+    }
+
+    yield byteList;
+  }
+}
+
+Stream<List<CoverData>> generateCoverThumbnails(
+  VideoEditorController controller, {
+  required int quantity,
+  int quality = 10,
+}) async* {
+  final int duration = controller.isTrimmmed
+      ? (controller.endTrim - controller.startTrim).inMilliseconds
+      : controller.videoDuration.inMilliseconds;
+  final double eachPart = duration / quantity;
+  List<CoverData> byteList = [];
+
+  for (int i = 0; i < quantity; i++) {
+    try {
+      final CoverData bytes = await generateSingleCoverThumbnail(
+        controller.file.path,
+        timeMs: (controller.isTrimmmed
+                ? (eachPart * i) + controller.startTrim.inMilliseconds
+                : (eachPart * i))
+            .toInt(),
+        quality: quality,
+      );
+
+      if (bytes.thumbData != null) {
+        byteList.add(bytes);
+      }
+    } catch (e) {
+      debugPrint(e.toString());
+    }
+
+    yield byteList;
+  }
+}
+
+/// Generate a cover at [timeMs] in video
+///
+/// return [CoverData] depending on [timeMs] milliseconds
+Future<CoverData> generateSingleCoverThumbnail(
+  String filePath, {
+  int timeMs = 0,
+  int quality = 10,
+}) async {
+  final Uint8List? thumbData = await VideoThumbnail.thumbnailData(
+    imageFormat: ImageFormat.JPEG,
+    video: filePath,
+    timeMs: timeMs,
+    quality: quality,
+  );
+
+  return CoverData(thumbData: thumbData, timeMs: timeMs);
+}

--- a/lib/domain/thumbnails.dart
+++ b/lib/domain/thumbnails.dart
@@ -38,7 +38,7 @@ Stream<List<CoverData>> generateCoverThumbnails(
   required int quantity,
   int quality = 10,
 }) async* {
-  final int duration = controller.isTrimmmed
+  final int duration = controller.isTrimmed
       ? (controller.endTrim - controller.startTrim).inMilliseconds
       : controller.videoDuration.inMilliseconds;
   final double eachPart = duration / quantity;
@@ -48,7 +48,7 @@ Stream<List<CoverData>> generateCoverThumbnails(
     try {
       final CoverData bytes = await generateSingleCoverThumbnail(
         controller.file.path,
-        timeMs: (controller.isTrimmmed
+        timeMs: (controller.isTrimmed
                 ? (eachPart * i) + controller.startTrim.inMilliseconds
                 : (eachPart * i))
             .toInt(),

--- a/lib/ui/cover/cover_selection.dart
+++ b/lib/ui/cover/cover_selection.dart
@@ -81,7 +81,7 @@ class _CoverSelectionState extends State<CoverSelection>
       _rect.value,
       _layout,
       _layout,
-      widget.controller,
+      null, // controller rotation should not affect this widget
     );
 
     // if trim values changed generate new thumbnails
@@ -187,14 +187,16 @@ class _CoverSelectionState extends State<CoverSelection>
     CoverSelectionStyle coverStyle, {
     required bool isSelected,
   }) {
-    return SizedBox.fromSize(
-      size: _layout,
-      child: CropTransform(
-        transform: transform,
-        child: AspectRatio(
-          aspectRatio: _aspect,
-          child: InkWell(
-            onTap: () => widget.controller.updateSelectedCover(cover),
+    // here the rotation should affect the dimension of the widget
+    // it is better to use [RotatedBox] instead of [Tranform.rotate]
+    return InkWell(
+      onTap: () => widget.controller.updateSelectedCover(cover),
+      child: RotatedBox(
+        quarterTurns: widget.controller.rotation ~/ -90,
+        child: SizedBox.fromSize(
+          size: _layout,
+          child: CropTransform(
+            transform: transform,
             child: Stack(
               alignment: coverStyle.selectedIndicatorAlign,
               children: [

--- a/lib/ui/cover/cover_selection.dart
+++ b/lib/ui/cover/cover_selection.dart
@@ -54,7 +54,7 @@ class _CoverSelectionState extends State<CoverSelection>
   Size _layout = Size.zero;
   final ValueNotifier<Rect> _rect = ValueNotifier<Rect>(Rect.zero);
   final ValueNotifier<TransformData> _transform =
-      ValueNotifier<TransformData>(TransformData());
+      ValueNotifier<TransformData>(const TransformData());
 
   late Stream<List<CoverData>> _stream = (() => _generateCoverThumbnails())();
 

--- a/lib/ui/cover/cover_selection.dart
+++ b/lib/ui/cover/cover_selection.dart
@@ -37,7 +37,6 @@ class CoverSelection extends StatefulWidget {
 
 class _CoverSelectionState extends State<CoverSelection>
     with AutomaticKeepAliveClientMixin {
-  double _aspect = 1.0;
   Duration? _startTrim, _endTrim;
 
   Size _layout = Size.zero;
@@ -58,23 +57,15 @@ class _CoverSelectionState extends State<CoverSelection>
   @override
   void initState() {
     super.initState();
-    _aspect = widget.controller.preferredCropAspectRatio ??
-        widget.controller.video.value.aspectRatio;
     _startTrim = widget.controller.startTrim;
     _endTrim = widget.controller.endTrim;
     widget.controller.addListener(_scaleRect);
-
-    // init the widget with controller values
-    WidgetsBinding.instance.addPostFrameCallback((_) => _scaleRect());
   }
 
   @override
   bool get wantKeepAlive => true;
 
   void _scaleRect() {
-    if (widget.controller.preferredCropAspectRatio != null) {
-      _aspect = widget.controller.preferredCropAspectRatio!;
-    }
     _rect.value = _calculateCoverRect();
 
     _transform.value = TransformData.fromRect(
@@ -132,10 +123,14 @@ class _CoverSelectionState extends State<CoverSelection>
     );
   }
 
-  Size _calculateLayout() {
-    return _aspect < 1.0
-        ? Size(widget.size * _aspect, widget.size)
-        : Size(widget.size, widget.size / _aspect);
+  /// Returns the max size the layout should take with the rect value
+  Size _calculateMaxLayout() {
+    final ratio = _rect.value == Rect.zero
+        ? widget.controller.video.value.aspectRatio
+        : _rect.value.size.aspectRatio;
+    return ratio < 1.0
+        ? Size(widget.size * ratio, widget.size)
+        : Size(widget.size, widget.size / ratio);
   }
 
   @override
@@ -190,7 +185,7 @@ class _CoverSelectionState extends State<CoverSelection>
           alignment: coverStyle.selectedIndicatorAlign,
           children: [
             Container(
-              constraints: BoxConstraints.tight(_calculateLayout()),
+              constraints: BoxConstraints.tight(_calculateMaxLayout()),
               decoration: BoxDecoration(
                 border: Border.all(
                   color: isSelected

--- a/lib/ui/cover/cover_selection.dart
+++ b/lib/ui/cover/cover_selection.dart
@@ -19,6 +19,7 @@ class CoverSelection extends StatefulWidget {
     this.size = 60,
     this.quality = 10,
     this.quantity = 5,
+    this.wrap,
     this.selectedCoverBuilder,
   });
 
@@ -39,6 +40,10 @@ class CoverSelection extends StatefulWidget {
   ///
   /// Default to `5`
   final int quantity;
+
+  /// Specifies a [wrap] param to change how should be displayed the covers thumbnails
+  /// the `children` param will be ommited
+  final Wrap? wrap;
 
   /// Returns how the selected cover should be displayed
   final Widget Function(Widget selectedCover, Size)? selectedCoverBuilder;
@@ -116,6 +121,7 @@ class _CoverSelectionState extends State<CoverSelection>
   @override
   Widget build(BuildContext context) {
     super.build(context);
+    final wrap = widget.wrap ?? Wrap();
 
     return StreamBuilder<List<CoverData>>(
         stream: _stream,
@@ -124,8 +130,15 @@ class _CoverSelectionState extends State<CoverSelection>
               ? ValueListenableBuilder<TransformData>(
                   valueListenable: _transform,
                   builder: (_, transform, __) => Wrap(
-                    runSpacing: 10.0,
-                    spacing: 10.0,
+                    direction: wrap.direction,
+                    alignment: wrap.alignment,
+                    spacing: widget.wrap?.spacing ?? 10.0,
+                    runSpacing: widget.wrap?.runSpacing ?? 10.0,
+                    runAlignment: wrap.runAlignment,
+                    crossAxisAlignment: wrap.crossAxisAlignment,
+                    textDirection: wrap.textDirection,
+                    verticalDirection: wrap.verticalDirection,
+                    clipBehavior: wrap.clipBehavior,
                     children: snapshot.data!
                         .map(
                           (coverData) => ValueListenableBuilder<CoverData?>(

--- a/lib/ui/cover/cover_selection.dart
+++ b/lib/ui/cover/cover_selection.dart
@@ -5,6 +5,7 @@ import 'package:video_editor/domain/entities/cover_data.dart';
 import 'package:video_editor/domain/entities/cover_style.dart';
 import 'package:video_editor/domain/entities/transform_data.dart';
 import 'package:video_editor/domain/helpers.dart';
+import 'package:video_editor/domain/thumbnails.dart';
 import 'package:video_editor/ui/crop/crop_grid_painter.dart';
 import 'package:video_editor/ui/image_viewer.dart';
 import 'package:video_editor/ui/transform.dart';
@@ -45,7 +46,7 @@ class _CoverSelectionState extends State<CoverSelection>
   final ValueNotifier<TransformData> _transform =
       ValueNotifier<TransformData>(TransformData());
 
-  late Stream<List<CoverData>> _stream = (() => _generateThumbnails())();
+  late Stream<List<CoverData>> _stream = (() => _generateCoverThumbnails())();
 
   @override
   void dispose() {
@@ -82,37 +83,15 @@ class _CoverSelectionState extends State<CoverSelection>
             _endTrim != widget.controller.endTrim)) {
       _startTrim = widget.controller.startTrim;
       _endTrim = widget.controller.endTrim;
-      setState(() => _stream = _generateThumbnails());
+      setState(() => _stream = _generateCoverThumbnails());
     }
   }
 
-  Stream<List<CoverData>> _generateThumbnails() async* {
-    final int duration = widget.controller.isTrimmmed
-        ? (widget.controller.endTrim - widget.controller.startTrim)
-            .inMilliseconds
-        : widget.controller.videoDuration.inMilliseconds;
-    final double eachPart = duration / widget.quantity;
-    List<CoverData> byteList = [];
-    for (int i = 0; i < widget.quantity; i++) {
-      try {
-        final CoverData bytes = await widget.controller.generateCoverThumbnail(
-            timeMs: (widget.controller.isTrimmmed
-                    ? (eachPart * i) +
-                        widget.controller.startTrim.inMilliseconds
-                    : (eachPart * i))
-                .toInt(),
-            quality: widget.quality);
-
-        if (bytes.thumbData != null) {
-          byteList.add(bytes);
-        }
-      } catch (e) {
-        debugPrint(e.toString());
-      }
-
-      yield byteList;
-    }
-  }
+  Stream<List<CoverData>> _generateCoverThumbnails() => generateCoverThumbnails(
+        widget.controller,
+        quantity: widget.quantity,
+        quality: widget.quality,
+      );
 
   /// Returns the max size the layout should take with the rect value
   Size _calculateMaxLayout() {

--- a/lib/ui/cover/cover_selection.dart
+++ b/lib/ui/cover/cover_selection.dart
@@ -189,7 +189,7 @@ class _CoverSelectionState extends State<CoverSelection>
                 transform: transform,
                 child: ImageViewer(
                   controller: widget.controller,
-                  image: Image(image: MemoryImage(cover.thumbData!)),
+                  bytes: cover.thumbData!,
                   child: LayoutBuilder(builder: (_, constraints) {
                     Size size = constraints.biggest;
                     if (_layout != size) {

--- a/lib/ui/cover/cover_selection.dart
+++ b/lib/ui/cover/cover_selection.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:video_editor/domain/entities/cover_data.dart';
 import 'package:video_editor/domain/entities/cover_style.dart';
 import 'package:video_editor/domain/entities/transform_data.dart';
+import 'package:video_editor/domain/helpers.dart';
 import 'package:video_editor/ui/crop/crop_grid_painter.dart';
 import 'package:video_editor/ui/image_viewer.dart';
 import 'package:video_editor/ui/transform.dart';
@@ -66,7 +67,7 @@ class _CoverSelectionState extends State<CoverSelection>
   bool get wantKeepAlive => true;
 
   void _scaleRect() {
-    _rect.value = _calculateCoverRect();
+    _rect.value = calculateCroppedRect(widget.controller, _layout);
 
     _transform.value = TransformData.fromRect(
       _rect.value,
@@ -111,16 +112,6 @@ class _CoverSelectionState extends State<CoverSelection>
 
       yield byteList;
     }
-  }
-
-  Rect _calculateCoverRect() {
-    final Offset min = widget.controller.minCrop;
-    final Offset max = widget.controller.maxCrop;
-
-    return Rect.fromPoints(
-      Offset(min.dx * _layout.width, min.dy * _layout.height),
-      Offset(max.dx * _layout.width, max.dy * _layout.height),
-    );
   }
 
   /// Returns the max size the layout should take with the rect value

--- a/lib/ui/cover/cover_viewer.dart
+++ b/lib/ui/cover/cover_viewer.dart
@@ -3,6 +3,7 @@ import 'package:video_editor/domain/entities/cover_data.dart';
 import 'package:video_editor/domain/entities/transform_data.dart';
 import 'package:video_editor/domain/bloc/controller.dart';
 import 'package:video_editor/ui/crop/crop_grid_painter.dart';
+import 'package:video_editor/ui/image_viewer.dart';
 import 'package:video_editor/ui/transform.dart';
 
 class CoverViewer extends StatefulWidget {
@@ -72,9 +73,9 @@ class _CoverViewerState extends State<CoverViewer> {
   //-----------//
   //RECT CHANGE//
   //-----------//
-  Rect _calculateCropRect([Offset? min, Offset? max]) {
-    final Offset minCrop = min ?? _controller.minCrop;
-    final Offset maxCrop = max ?? _controller.maxCrop;
+  Rect _calculateCropRect() {
+    final Offset minCrop = _controller.minCrop;
+    final Offset maxCrop = _controller.maxCrop;
 
     return Rect.fromPoints(
       Offset(minCrop.dx * _layout.width, minCrop.dy * _layout.height),
@@ -88,58 +89,48 @@ class _CoverViewerState extends State<CoverViewer> {
       _viewerSize = constraints.biggest;
 
       return ValueListenableBuilder(
-          valueListenable: _transform,
-          builder: (_, TransformData transform, __) => ValueListenableBuilder(
-              valueListenable: widget.controller.selectedCoverNotifier,
-              builder: (context, CoverData? selectedCover, __) =>
-                  selectedCover?.thumbData == null
-                      ? Center(child: Text(widget.noCoverText))
-                      : CropTransform(
-                          transform: transform,
-                          child: Center(
-                              child: Stack(children: [
-                            AspectRatio(
-                              aspectRatio:
-                                  widget.controller.video.value.aspectRatio,
-                              child: Image(
-                                image: MemoryImage(selectedCover!.thumbData!),
-                                alignment: Alignment.center,
-                              ),
-                            ),
-                            AspectRatio(
-                                aspectRatio:
-                                    widget.controller.video.value.aspectRatio,
-                                child: LayoutBuilder(
-                                  builder: (_, constraints) {
-                                    Size size = constraints.biggest;
-                                    if (_layout != size) {
-                                      _layout = size;
-                                      // init the widget with controller values
-                                      WidgetsBinding.instance
-                                          .addPostFrameCallback((_) {
-                                        _scaleRect();
-                                      });
-                                    }
+        valueListenable: _transform,
+        builder: (_, TransformData transform, __) => ValueListenableBuilder(
+          valueListenable: widget.controller.selectedCoverNotifier,
+          builder: (context, CoverData? selectedCover, __) => selectedCover
+                      ?.thumbData ==
+                  null
+              ? Center(child: Text(widget.noCoverText))
+              : CropTransform(
+                  transform: transform,
+                  child: ImageViewer(
+                    controller: widget.controller,
+                    image: Image(image: MemoryImage(selectedCover!.thumbData!)),
+                    child: LayoutBuilder(
+                      builder: (_, constraints) {
+                        Size size = constraints.biggest;
+                        if (_layout != size) {
+                          _layout = size;
+                          // init the widget with controller values
+                          WidgetsBinding.instance
+                              .addPostFrameCallback((_) => _scaleRect());
+                        }
 
-                                    return ValueListenableBuilder(
-                                      valueListenable: _rect,
-                                      builder: (_, Rect value, __) {
-                                        return CustomPaint(
-                                          size: Size.infinite,
-                                          painter: CropGridPainter(
-                                            value,
-                                            style: _controller.cropStyle,
-                                            showGrid: false,
-                                            showCenterRects: _controller
-                                                    .preferredCropAspectRatio ==
-                                                null,
-                                          ),
-                                        );
-                                      },
-                                    );
-                                  },
-                                ))
-                          ])))));
+                        return ValueListenableBuilder(
+                          valueListenable: _rect,
+                          builder: (_, Rect value, __) {
+                            return CustomPaint(
+                              size: Size.infinite,
+                              painter: CropGridPainter(
+                                value,
+                                style: _controller.cropStyle,
+                                showGrid: false,
+                                showCenterRects: false,
+                              ),
+                            );
+                          },
+                        );
+                      },
+                    ),
+                  ),
+                ),
+        ),
+      );
     });
   }
 }

--- a/lib/ui/cover/cover_viewer.dart
+++ b/lib/ui/cover/cover_viewer.dart
@@ -28,7 +28,7 @@ class CoverViewer extends StatefulWidget {
 class _CoverViewerState extends State<CoverViewer> {
   final ValueNotifier<Rect> _rect = ValueNotifier<Rect>(Rect.zero);
   final ValueNotifier<TransformData> _transform =
-      ValueNotifier<TransformData>(TransformData());
+      ValueNotifier<TransformData>(const TransformData());
 
   Size _viewerSize = Size.zero;
   Size _layout = Size.zero;

--- a/lib/ui/cover/cover_viewer.dart
+++ b/lib/ui/cover/cover_viewer.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:video_editor/domain/entities/cover_data.dart';
 import 'package:video_editor/domain/entities/transform_data.dart';
 import 'package:video_editor/domain/bloc/controller.dart';
+import 'package:video_editor/domain/helpers.dart';
 import 'package:video_editor/ui/crop/crop_grid_painter.dart';
 import 'package:video_editor/ui/image_viewer.dart';
 import 'package:video_editor/ui/transform.dart';
@@ -53,7 +54,7 @@ class _CoverViewerState extends State<CoverViewer> {
   }
 
   void _scaleRect() {
-    _rect.value = _calculateCropRect();
+    _rect.value = calculateCroppedRect(widget.controller, _layout);
     _transform.value = TransformData.fromRect(
       _rect.value,
       _layout,
@@ -68,19 +69,6 @@ class _CoverViewerState extends State<CoverViewer> {
     if (widget.controller.selectedCoverVal!.thumbData == null) {
       widget.controller.generateDefaultCoverThumbnail();
     }
-  }
-
-  //-----------//
-  //RECT CHANGE//
-  //-----------//
-  Rect _calculateCropRect() {
-    final Offset minCrop = _controller.minCrop;
-    final Offset maxCrop = _controller.maxCrop;
-
-    return Rect.fromPoints(
-      Offset(minCrop.dx * _layout.width, minCrop.dy * _layout.height),
-      Offset(maxCrop.dx * _layout.width, maxCrop.dy * _layout.height),
-    );
   }
 
   @override

--- a/lib/ui/cover/cover_viewer.dart
+++ b/lib/ui/cover/cover_viewer.dart
@@ -33,21 +33,16 @@ class _CoverViewerState extends State<CoverViewer> {
   Size _viewerSize = Size.zero;
   Size _layout = Size.zero;
 
-  late VideoEditorController _controller;
-
   @override
   void initState() {
-    _controller = widget.controller;
-    _controller.addListener(_scaleRect);
-
-    _checkIfCoverIsNull();
-
     super.initState();
+    widget.controller.addListener(_scaleRect);
+    _checkIfCoverIsNull();
   }
 
   @override
   void dispose() {
-    _controller.removeListener(_scaleRect);
+    widget.controller.removeListener(_scaleRect);
     _transform.dispose();
     _rect.dispose();
     super.dispose();
@@ -59,7 +54,7 @@ class _CoverViewerState extends State<CoverViewer> {
       _rect.value,
       _layout,
       _viewerSize,
-      _controller,
+      widget.controller,
     );
 
     _checkIfCoverIsNull();
@@ -105,7 +100,7 @@ class _CoverViewerState extends State<CoverViewer> {
                                   size: Size.infinite,
                                   painter: CropGridPainter(
                                     value,
-                                    style: _controller.cropStyle,
+                                    style: widget.controller.cropStyle,
                                     showGrid: false,
                                     showCenterRects: false,
                                   ),

--- a/lib/ui/cover/cover_viewer.dart
+++ b/lib/ui/cover/cover_viewer.dart
@@ -80,43 +80,42 @@ class _CoverViewerState extends State<CoverViewer> {
         valueListenable: _transform,
         builder: (_, TransformData transform, __) => ValueListenableBuilder(
           valueListenable: widget.controller.selectedCoverNotifier,
-          builder: (context, CoverData? selectedCover, __) => selectedCover
-                      ?.thumbData ==
-                  null
-              ? Center(child: Text(widget.noCoverText))
-              : CropTransform(
-                  transform: transform,
-                  child: ImageViewer(
-                    controller: widget.controller,
-                    image: Image(image: MemoryImage(selectedCover!.thumbData!)),
-                    child: LayoutBuilder(
-                      builder: (_, constraints) {
-                        Size size = constraints.biggest;
-                        if (_layout != size) {
-                          _layout = size;
-                          // init the widget with controller values
-                          WidgetsBinding.instance
-                              .addPostFrameCallback((_) => _scaleRect());
-                        }
+          builder: (context, CoverData? selectedCover, __) =>
+              selectedCover?.thumbData == null
+                  ? Center(child: Text(widget.noCoverText))
+                  : CropTransform(
+                      transform: transform,
+                      child: ImageViewer(
+                        controller: widget.controller,
+                        bytes: selectedCover!.thumbData!,
+                        child: LayoutBuilder(
+                          builder: (_, constraints) {
+                            Size size = constraints.biggest;
+                            if (_layout != size) {
+                              _layout = size;
+                              // init the widget with controller values
+                              WidgetsBinding.instance
+                                  .addPostFrameCallback((_) => _scaleRect());
+                            }
 
-                        return ValueListenableBuilder(
-                          valueListenable: _rect,
-                          builder: (_, Rect value, __) {
-                            return CustomPaint(
-                              size: Size.infinite,
-                              painter: CropGridPainter(
-                                value,
-                                style: _controller.cropStyle,
-                                showGrid: false,
-                                showCenterRects: false,
-                              ),
+                            return ValueListenableBuilder(
+                              valueListenable: _rect,
+                              builder: (_, Rect value, __) {
+                                return CustomPaint(
+                                  size: Size.infinite,
+                                  painter: CropGridPainter(
+                                    value,
+                                    style: _controller.cropStyle,
+                                    showGrid: false,
+                                    showCenterRects: false,
+                                  ),
+                                );
+                              },
                             );
                           },
-                        );
-                      },
+                        ),
+                      ),
                     ),
-                  ),
-                ),
         ),
       );
     });

--- a/lib/ui/crop/crop_grid.dart
+++ b/lib/ui/crop/crop_grid.dart
@@ -48,7 +48,7 @@ class CropGridViewer extends StatefulWidget {
 class _CropGridViewerState extends State<CropGridViewer> {
   final ValueNotifier<Rect> _rect = ValueNotifier<Rect>(Rect.zero);
   final ValueNotifier<TransformData> _transform =
-      ValueNotifier<TransformData>(TransformData());
+      ValueNotifier<TransformData>(const TransformData());
 
   Size _viewerSize = Size.zero;
   Size _layout = Size.zero;

--- a/lib/ui/crop/crop_grid.dart
+++ b/lib/ui/crop/crop_grid.dart
@@ -310,9 +310,7 @@ class _CropGridViewerState extends State<CropGridViewer> {
             child: Container(
                 // when widget.showGrid is true, the layout size should never be bigger than the screen size
                 constraints: BoxConstraints(
-                    maxHeight: ((_controller.rotation == 90 ||
-                                _controller.rotation == 270)) &&
-                            widget.showGrid
+                    maxHeight: _controller.isRotated && widget.showGrid
                         ? MediaQuery.of(context).size.width -
                             widget.horizontalMargin
                         : Size.infinite.height),

--- a/lib/ui/crop/crop_grid.dart
+++ b/lib/ui/crop/crop_grid.dart
@@ -101,9 +101,11 @@ class _CropGridViewerState extends State<CropGridViewer> {
     _preferredCropAspectRatio = _controller.preferredCropAspectRatio;
 
     // set cached crop values to adjust it later
-    _rect.value = _calculateCropRect(
-      _controller.cacheMinCrop,
-      _controller.cacheMaxCrop,
+    _rect.value = calculateCroppedRect(
+      _controller,
+      _layout,
+      min: _controller.cacheMinCrop,
+      max: _controller.cacheMaxCrop,
     );
 
     setState(() {
@@ -119,7 +121,7 @@ class _CropGridViewerState extends State<CropGridViewer> {
   }
 
   void _scaleRect() {
-    _rect.value = _calculateCropRect();
+    _rect.value = calculateCroppedRect(_controller, _layout);
     _transform.value = TransformData.fromRect(
       _rect.value,
       _layout,
@@ -297,18 +299,6 @@ class _CropGridViewerState extends State<CropGridViewer> {
     _rect.value = Rect.fromLTRB(left, top, right, bottom);
   }
 
-  /// Calculate crop [Rect] area
-  /// depending of [_controller] min and max crop values and the size of the layout
-  Rect _calculateCropRect([Offset? min, Offset? max]) {
-    final Offset minCrop = min ?? _controller.minCrop;
-    final Offset maxCrop = max ?? _controller.maxCrop;
-
-    return Rect.fromPoints(
-      Offset(minCrop.dx * _layout.width, minCrop.dy * _layout.height),
-      Offset(maxCrop.dx * _layout.width, maxCrop.dy * _layout.height),
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     return LayoutBuilder(builder: (_, constraints) {
@@ -340,7 +330,8 @@ class _CropGridViewerState extends State<CropGridViewer> {
                               _calculatePreferedCrop();
                             });
                           } else {
-                            _rect.value = _calculateCropRect();
+                            _rect.value =
+                                calculateCroppedRect(_controller, _layout);
                           }
                         }
                         return ValueListenableBuilder(

--- a/lib/ui/crop/crop_grid_painter.dart
+++ b/lib/ui/crop/crop_grid_painter.dart
@@ -5,11 +5,13 @@ class CropGridPainter extends CustomPainter {
   CropGridPainter(
     this.rect, {
     this.style,
+    this.radius = 0,
     this.showGrid = false,
     this.showCenterRects = true,
   });
 
   final Rect rect;
+  final double radius;
   final CropGridStyle? style;
   final bool showGrid, showCenterRects;
 
@@ -38,7 +40,7 @@ class CropGridPainter extends CustomPainter {
           ..addRect(Rect.fromLTWH(-margin, -margin, size.width + margin * 2,
               size.height + margin * 2)),
         Path()
-          ..addRect(rect)
+          ..addRRect(RRect.fromRectAndRadius(rect, Radius.circular(radius)))
           ..close(),
       ),
       paint,

--- a/lib/ui/image_viewer.dart
+++ b/lib/ui/image_viewer.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
+import 'package:transparent_image/transparent_image.dart';
 import 'package:video_editor/domain/bloc/controller.dart';
 
 class ImageViewer extends StatelessWidget {
@@ -9,11 +10,13 @@ class ImageViewer extends StatelessWidget {
     required this.controller,
     required this.bytes,
     this.child,
+    this.fadeIn = true,
   }) : super(key: key);
 
   final VideoEditorController controller;
   final Uint8List bytes;
   final Widget? child;
+  final bool fadeIn;
 
   @override
   Widget build(BuildContext context) {
@@ -22,7 +25,13 @@ class ImageViewer extends StatelessWidget {
         children: [
           AspectRatio(
             aspectRatio: controller.video.value.aspectRatio,
-            child: Image(image: MemoryImage(bytes)),
+            child: fadeIn
+                ? FadeInImage(
+                    fadeInDuration: const Duration(milliseconds: 400),
+                    image: MemoryImage(bytes),
+                    placeholder: MemoryImage(kTransparentImage),
+                  )
+                : Image.memory(bytes),
           ),
           if (child != null)
             AspectRatio(

--- a/lib/ui/image_viewer.dart
+++ b/lib/ui/image_viewer.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
 import 'package:video_editor/domain/bloc/controller.dart';
 
@@ -5,12 +7,12 @@ class ImageViewer extends StatelessWidget {
   const ImageViewer({
     Key? key,
     required this.controller,
-    required this.image,
+    required this.bytes,
     this.child,
   }) : super(key: key);
 
   final VideoEditorController controller;
-  final Image image;
+  final Uint8List bytes;
   final Widget? child;
 
   @override
@@ -20,7 +22,7 @@ class ImageViewer extends StatelessWidget {
         children: [
           AspectRatio(
             aspectRatio: controller.video.value.aspectRatio,
-            child: image,
+            child: Image(image: MemoryImage(bytes)),
           ),
           if (child != null)
             AspectRatio(

--- a/lib/ui/image_viewer.dart
+++ b/lib/ui/image_viewer.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:video_editor/domain/bloc/controller.dart';
+
+class ImageViewer extends StatelessWidget {
+  const ImageViewer({
+    Key? key,
+    required this.controller,
+    required this.image,
+    this.child,
+  }) : super(key: key);
+
+  final VideoEditorController controller;
+  final Image image;
+  final Widget? child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Stack(
+        children: [
+          AspectRatio(
+            aspectRatio: controller.video.value.aspectRatio,
+            child: image,
+          ),
+          if (child != null)
+            AspectRatio(
+              aspectRatio: controller.video.value.aspectRatio,
+              child: child,
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/trim/thumbnail_slider.dart
+++ b/lib/ui/trim/thumbnail_slider.dart
@@ -32,7 +32,7 @@ class ThumbnailSlider extends StatefulWidget {
 class _ThumbnailSliderState extends State<ThumbnailSlider> {
   final ValueNotifier<Rect> _rect = ValueNotifier<Rect>(Rect.zero);
   final ValueNotifier<TransformData> _transform =
-      ValueNotifier<TransformData>(TransformData());
+      ValueNotifier<TransformData>(const TransformData());
 
   /// The max width of [ThumbnailSlider]
   double _sliderWidth = 1.0;

--- a/lib/ui/trim/thumbnail_slider.dart
+++ b/lib/ui/trim/thumbnail_slider.dart
@@ -123,11 +123,24 @@ class _ThumbnailSliderState extends State<ThumbnailSlider> {
                       final index =
                           getBestIndex(_neededThumbnails, data!.length, i);
 
-                      if (index >= data.length) {
-                        return const SizedBox();
-                      }
-
-                      return _buildSingleThumbnail(data[index], transform);
+                      return Stack(
+                        children: [
+                          Opacity(
+                            opacity: 0.2,
+                            child: _buildSingleThumbnail(
+                              data[0],
+                              transform,
+                              isPlaceholder: true,
+                            ),
+                          ),
+                          if (index < data.length)
+                            _buildSingleThumbnail(
+                              data[index],
+                              transform,
+                              isPlaceholder: false,
+                            ),
+                        ],
+                      );
                     },
                   ),
                 )
@@ -137,7 +150,11 @@ class _ThumbnailSliderState extends State<ThumbnailSlider> {
     });
   }
 
-  Widget _buildSingleThumbnail(Uint8List bytes, TransformData transform) {
+  Widget _buildSingleThumbnail(
+    Uint8List bytes,
+    TransformData transform, {
+    required bool isPlaceholder,
+  }) {
     return Container(
       constraints: BoxConstraints.tight(_maxLayout),
       child: CropTransform(
@@ -145,9 +162,10 @@ class _ThumbnailSliderState extends State<ThumbnailSlider> {
         child: ImageViewer(
           controller: widget.controller,
           bytes: bytes,
+          fadeIn: !isPlaceholder,
           child: LayoutBuilder(builder: (_, constraints) {
             Size size = constraints.biggest;
-            if (_layout != size) {
+            if (!isPlaceholder && _layout != size) {
               _layout = size;
               // init the widget with controller values
               WidgetsBinding.instance.addPostFrameCallback((_) => _scaleRect());

--- a/lib/ui/trim/thumbnail_slider.dart
+++ b/lib/ui/trim/thumbnail_slider.dart
@@ -4,10 +4,10 @@ import 'package:flutter/material.dart';
 import 'package:video_editor/domain/bloc/controller.dart';
 import 'package:video_editor/domain/entities/transform_data.dart';
 import 'package:video_editor/domain/helpers.dart';
+import 'package:video_editor/domain/thumbnails.dart';
 import 'package:video_editor/ui/crop/crop_grid_painter.dart';
 import 'package:video_editor/ui/image_viewer.dart';
 import 'package:video_editor/ui/transform.dart';
-import 'package:video_thumbnail/video_thumbnail.dart';
 
 class ThumbnailSlider extends StatefulWidget {
   const ThumbnailSlider({
@@ -78,29 +78,11 @@ class _ThumbnailSliderState extends State<ThumbnailSlider> {
     }
   }
 
-  Stream<List<Uint8List>> _generateThumbnails() async* {
-    final String path = widget.controller.file.path;
-    final int duration = widget.controller.video.value.duration.inMilliseconds;
-    final double eachPart = duration / _thumbnailsCount;
-    List<Uint8List> byteList = [];
-    for (int i = 1; i <= _thumbnailsCount; i++) {
-      try {
-        final Uint8List? bytes = await VideoThumbnail.thumbnailData(
-          imageFormat: ImageFormat.JPEG,
-          video: path,
-          timeMs: (eachPart * i).toInt(),
-          quality: widget.quality,
-        );
-        if (bytes != null) {
-          byteList.add(bytes);
-        }
-      } catch (e) {
-        debugPrint(e.toString());
-      }
-
-      yield byteList;
-    }
-  }
+  Stream<List<Uint8List>> _generateThumbnails() => generateTrimThumbnails(
+        widget.controller,
+        quantity: _thumbnailsCount,
+        quality: widget.quality,
+      );
 
   /// Returns the max size the layout should take with the rect value
   Size _calculateMaxLayout() {

--- a/lib/ui/trim/thumbnail_slider.dart
+++ b/lib/ui/trim/thumbnail_slider.dart
@@ -69,11 +69,6 @@ class _ThumbnailSliderState extends State<ThumbnailSlider> {
       _maxLayout, // the maximum size to show the thumb
       widget.controller,
     );
-    // if rotated, increase scale to fit all `ThumbnailSlider` space
-    if (widget.controller.isRotated) {
-      _transform.value = _transform.value
-          .copyWith(scale: scaleToSizeMax(_maxLayout, _rect.value));
-    }
 
     // regenerate thumbnails if need more to fit the slider
     final neededThumbs = (_sliderWidth ~/ _maxLayout.width) + 1;
@@ -119,7 +114,7 @@ class _ThumbnailSliderState extends State<ThumbnailSlider> {
     final size = Size(widget.height * ratio, widget.height);
 
     if (widget.controller.isRotated) {
-      return size.flipped;
+      return Size(widget.height / ratio, widget.height);
     }
     return size;
   }

--- a/lib/ui/trim/thumbnail_slider.dart
+++ b/lib/ui/trim/thumbnail_slider.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:video_editor/domain/bloc/controller.dart';
 import 'package:video_editor/domain/entities/transform_data.dart';
+import 'package:video_editor/domain/helpers.dart';
 import 'package:video_editor/ui/crop/crop_grid_painter.dart';
 import 'package:video_editor/ui/transform.dart';
 import 'package:video_thumbnail/video_thumbnail.dart';
@@ -62,7 +63,7 @@ class _ThumbnailSliderState extends State<ThumbnailSlider> {
   }
 
   void _scaleRect() {
-    _rect.value = _calculateTrimRect();
+    _rect.value = calculateCroppedRect(widget.controller, _layout);
     _transform.value = TransformData.fromRect(
       _rect.value,
       _layout,
@@ -95,21 +96,6 @@ class _ThumbnailSliderState extends State<ThumbnailSlider> {
     }
   }
 
-  Rect _calculateTrimRect() {
-    final Offset min = widget.controller.minCrop;
-    final Offset max = widget.controller.maxCrop;
-    return Rect.fromPoints(
-      Offset(
-        min.dx * _layout.width,
-        min.dy * _layout.height,
-      ),
-      Offset(
-        max.dx * _layout.width,
-        max.dy * _layout.height,
-      ),
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     return LayoutBuilder(builder: (_, box) {
@@ -121,7 +107,7 @@ class _ThumbnailSliderState extends State<ThumbnailSlider> {
             ? Size(widget.height * _aspect, widget.height)
             : Size(widget.height, widget.height / _aspect);
         _thumbnails = (_width ~/ _layout.width) + 1;
-        _rect.value = _calculateTrimRect();
+        _rect.value = calculateCroppedRect(widget.controller, _layout);
       }
 
       return StreamBuilder(

--- a/lib/ui/trim/trim_slider.dart
+++ b/lib/ui/trim/trim_slider.dart
@@ -323,6 +323,7 @@ class _TrimSliderState extends State<TrimSlider>
                 builder: (_, __) {
                   return CustomPaint(
                     size: Size.fromHeight(widget.height),
+                    // TODO : left and right edges should not overlap the thumbnails
                     painter: TrimSliderPainter(
                       _rect,
                       _getTrimPosition(),

--- a/lib/ui/trim/trim_slider.dart
+++ b/lib/ui/trim/trim_slider.dart
@@ -8,25 +8,31 @@ enum _TrimBoundaries { left, right, inside, progress, none }
 class TrimSlider extends StatefulWidget {
   /// Slider that trim video length.
   const TrimSlider({
-    Key? key,
+    super.key,
     required this.controller,
     this.height = 60,
     this.quality = 10,
     this.horizontalMargin = 0.0,
     this.child,
-  }) : super(key: key);
+  });
 
   /// The [controller] param is mandatory so every change in the controller settings will propagate in the trim slider view
   final VideoEditorController controller;
 
   /// The [height] param specifies the height of the generated thumbnails
+  ///
+  /// Defaults to `60`
   final double height;
 
   /// The [quality] param specifies the quality of the generated thumbnails, from 0 to 100 (([more info](https://pub.dev/packages/video_thumbnail)))
+  ///
+  /// Defaults to `10`
   final int quality;
 
   /// The [horizontalMargin] param specifies the horizontal space to set around the slider.
   /// It is important when the trim can be dragged (`controller.maxDuration` < `controller.videoDuration`)
+  ///
+  /// Defaults to `0`
   final double horizontalMargin;
 
   /// The [child] param can be specify to display a widget below this one (e.g: [TrimTimeline])
@@ -93,14 +99,14 @@ class _TrimSliderState extends State<TrimSlider>
 
   void _onHorizontalDragUpdate(DragUpdateDetails details) {
     final Offset delta = details.delta;
-    final trimWidth = widget.controller.trimStyle.lineWidth;
+    final edgeWidth = widget.controller.trimStyle.edgeWidth;
 
     switch (_boundary) {
       case _TrimBoundaries.left:
         final pos = _rect.topLeft + delta;
         // avoid minTrim to be bigger than maxTrim
         if (pos.dx > widget.horizontalMargin &&
-            pos.dx < _rect.right - trimWidth * 2) {
+            pos.dx < _rect.right - edgeWidth * 2) {
           _changeTrimRect(left: pos.dx, width: _rect.width - delta.dx);
         }
         break;
@@ -108,7 +114,7 @@ class _TrimSliderState extends State<TrimSlider>
         final pos = _rect.topRight + delta;
         // avoid maxTrim to be smaller than minTrim
         if (pos.dx < _trimLayout.width + widget.horizontalMargin &&
-            pos.dx > _rect.left + trimWidth * 2) {
+            pos.dx > _rect.left + edgeWidth * 2) {
           _changeTrimRect(width: _rect.width + delta.dx);
         }
         break;
@@ -317,6 +323,7 @@ class _TrimSliderState extends State<TrimSlider>
                       _rect,
                       _getTrimPosition(),
                       widget.controller.trimStyle,
+                      isTrimming: widget.controller.isTrimming,
                     ),
                   );
                 },

--- a/lib/ui/trim/trim_slider.dart
+++ b/lib/ui/trim/trim_slider.dart
@@ -280,13 +280,17 @@ class _TrimSliderState extends State<TrimSlider>
                   ),
                   child: Column(
                     children: [
-                      SizedBox(
-                        height: widget.height,
-                        width: _fullLayout.width,
-                        child: ThumbnailSlider(
-                          controller: widget.controller,
+                      ClipRRect(
+                        borderRadius: BorderRadius.circular(
+                            widget.controller.trimStyle.borderRadius),
+                        child: SizedBox(
                           height: widget.height,
-                          quality: widget.quality,
+                          width: _fullLayout.width,
+                          child: ThumbnailSlider(
+                            controller: widget.controller,
+                            height: widget.height,
+                            quality: widget.quality,
+                          ),
                         ),
                       ),
                       if (widget.child != null)

--- a/lib/ui/trim/trim_slider.dart
+++ b/lib/ui/trim/trim_slider.dart
@@ -111,23 +111,20 @@ class _TrimSliderState extends State<TrimSlider>
 
   void _onHorizontalDragUpdate(DragUpdateDetails details) {
     final Offset delta = details.delta;
-    final edgeWidth = widget.controller.trimStyle.edgeWidth;
-
     final posLeft = _rect.topLeft + delta;
     final posRight = _rect.topRight + delta;
 
     switch (_boundary) {
       case _TrimBoundaries.left:
         // avoid minTrim to be bigger than maxTrim
-        if (posLeft.dx > _horizontalMargin &&
-            posLeft.dx < _rect.right - edgeWidth * 2) {
+        if (posLeft.dx > _horizontalMargin && posLeft.dx < _rect.right) {
           _changeTrimRect(left: posLeft.dx, width: _rect.width - delta.dx);
         }
         break;
       case _TrimBoundaries.right:
         // avoid maxTrim to be smaller than minTrim
         if (posRight.dx < _trimLayout.width + _horizontalMargin &&
-            posRight.dx > _rect.left + edgeWidth * 2) {
+            posRight.dx > _rect.left) {
           _changeTrimRect(width: _rect.width + delta.dx);
         }
         break;

--- a/lib/ui/trim/trim_slider.dart
+++ b/lib/ui/trim/trim_slider.dart
@@ -175,14 +175,18 @@ class _TrimSliderState extends State<TrimSlider>
     final isNotMax = _rect.right != _trimLayout.width + _horizontalMargin;
 
     // if touch left edge, set left to minimum (UI can be not accurate)
-    if (isNotMin && left - _horizontalMargin < 1) {
+    if (isNotMin &&
+        left - _horizontalMargin < 1 &&
+        _scrollController.offset < _horizontalMargin) {
       shouldHaptic = true;
       width += left - _horizontalMargin; // to not affect width by changing left
       left = _horizontalMargin;
     }
     // if touch right edge, set right to maximum (UI can be not accurate)
     if (isNotMax &&
-        (_trimLayout.width + _horizontalMargin) - (left + width) < 1) {
+        (_trimLayout.width + _horizontalMargin) - (left + width) < 1 &&
+        _scrollController.offset ==
+            _scrollController.position.maxScrollExtent) {
       shouldHaptic = true;
       width = _trimLayout.width + _horizontalMargin - left;
     }

--- a/lib/ui/trim/trim_slider.dart
+++ b/lib/ui/trim/trim_slider.dart
@@ -56,7 +56,6 @@ class _TrimSliderState extends State<TrimSlider>
   Size _fullLayout = Size.zero;
 
   final _scrollController = ScrollController();
-  double _thumbnailPosition = 0.0;
 
   /// Set to `true` if the video was playing before the gesture
   bool _isVideoPlayerHold = false;
@@ -240,7 +239,8 @@ class _TrimSliderState extends State<TrimSlider>
   /// If the expected position is bigger than [controller.endTrim], set it to [controller.endTrim]
   void _controllerSeekTo(double position) async {
     final to = widget.controller.videoDuration *
-        (position / (_fullLayout.width + _horizontalMargin * 2));
+        ((position + _scrollController.offset) /
+            (_fullLayout.width + _horizontalMargin * 2));
     await widget.controller.video.seekTo(
         to > widget.controller.endTrim ? widget.controller.endTrim : to);
   }
@@ -248,9 +248,9 @@ class _TrimSliderState extends State<TrimSlider>
   void _updateControllerTrim() {
     final double width = _fullLayout.width;
     final startTrim =
-        (_rect.left + _thumbnailPosition - _horizontalMargin) / width;
+        (_rect.left + _scrollController.offset - _horizontalMargin) / width;
     final endTrim =
-        (_rect.right + _thumbnailPosition - _horizontalMargin) / width;
+        (_rect.right + _scrollController.offset - _horizontalMargin) / width;
 
     widget.controller.updateTrim(startTrim, endTrim);
     _resetControllerPosition(startTrim, endTrim);
@@ -275,7 +275,7 @@ class _TrimSliderState extends State<TrimSlider>
   // Using function instead of getter seems faster when grabbing the cursor
   double _getTrimPosition() =>
       _fullLayout.width * widget.controller.trimPosition -
-      _thumbnailPosition +
+      _scrollController.offset +
       _horizontalMargin;
 
   Duration _getDurationDiff(double left, double width) {
@@ -337,10 +337,9 @@ class _TrimSliderState extends State<TrimSlider>
               onNotification: (notification) {
                 _boundary = _TrimBoundaries.inside;
                 _updateControllerIsTrimming(true);
+                _updateControllerTrim();
                 if (notification is ScrollEndNotification) {
-                  _thumbnailPosition = notification.metrics.pixels;
                   _updateControllerIsTrimming(false);
-                  _updateControllerTrim();
                 }
                 return true;
               },

--- a/lib/ui/trim/trim_slider.dart
+++ b/lib/ui/trim/trim_slider.dart
@@ -359,6 +359,7 @@ class _TrimSliderState extends State<TrimSlider>
                       _getTrimPosition(),
                       widget.controller.trimStyle,
                       isTrimming: widget.controller.isTrimming,
+                      isTrimmed: widget.controller.isTrimmed,
                     ),
                   );
                 },

--- a/lib/ui/trim/trim_slider_painter.dart
+++ b/lib/ui/trim/trim_slider_painter.dart
@@ -135,7 +135,7 @@ class TrimSliderPainter extends CustomPainter {
           Rect.fromCenter(
             center: centerLeft,
             width: style.edgesSize,
-            height: size.height,
+            height: size.height + style.lineWidth * 2,
           ),
         )
         // RIGTH EDGE
@@ -143,7 +143,7 @@ class TrimSliderPainter extends CustomPainter {
           Rect.fromCenter(
             center: centerRight,
             width: style.edgesSize,
-            height: size.height,
+            height: size.height + style.lineWidth * 2,
           ),
         );
     }

--- a/lib/ui/trim/trim_slider_painter.dart
+++ b/lib/ui/trim/trim_slider_painter.dart
@@ -7,10 +7,11 @@ class TrimSliderPainter extends CustomPainter {
     this.position,
     this.style, {
     this.isTrimming = false,
+    this.isTrimmed = false,
   });
 
   final Rect rect;
-  final bool isTrimming;
+  final bool isTrimming, isTrimmed;
   final double position;
   final TrimSliderStyle style;
 
@@ -36,7 +37,11 @@ class TrimSliderPainter extends CustomPainter {
       background,
     );
 
-    final trimColor = isTrimming ? style.onTrimmingColor : style.lineColor;
+    final trimColor = isTrimming
+        ? style.onTrimmingColor
+        : isTrimmed
+            ? style.onTrimmedColor
+            : style.lineColor;
     final line = Paint()
       ..color = trimColor
       ..style = PaintingStyle.stroke

--- a/lib/ui/trim/trim_slider_painter.dart
+++ b/lib/ui/trim/trim_slider_painter.dart
@@ -16,20 +16,7 @@ class TrimSliderPainter extends CustomPainter {
 
   @override
   void paint(Canvas canvas, Size size) {
-    final trimColor = isTrimming ? style.onTrimmingColor : style.lineColor;
-
     final Paint background = Paint()..color = style.background;
-    final progress = Paint()
-      ..color = style.positionLineColor
-      ..strokeWidth = style.positionLineWidth;
-    final line = Paint()
-      ..color = trimColor
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = style.lineWidth;
-    final circle = Paint()..color = trimColor;
-
-    final double halfLineWidth = style.lineWidth / 2;
-    final double halfHeight = rect.height / 2;
 
     final rrect = RRect.fromRectAndRadius(
       rect,
@@ -49,8 +36,130 @@ class TrimSliderPainter extends CustomPainter {
       background,
     );
 
+    final trimColor = isTrimming ? style.onTrimmingColor : style.lineColor;
+    final line = Paint()
+      ..color = trimColor
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = style.lineWidth;
+    final edges = Paint()..color = trimColor;
+
+    final double halfLineWidth = style.lineWidth / 2;
+    final double halfHeight = rect.height / 2;
+
+    final centerLeft = Offset(rect.left + halfLineWidth, halfHeight);
+    final centerRight = Offset(rect.right - halfLineWidth, halfHeight);
+
+    switch (style.edgesType) {
+      case TrimSliderEdgesType.bar:
+        paintBar(
+          canvas,
+          size,
+          rrect: rrect,
+          line: line,
+          edges: edges,
+          centerLeft: centerLeft,
+          centerRight: centerRight,
+          halfLineWidth: halfLineWidth,
+        );
+        break;
+      case TrimSliderEdgesType.circle:
+        paintCircle(
+          canvas,
+          size,
+          rrect: rrect,
+          line: line,
+          edges: edges,
+          centerLeft: centerLeft,
+          centerRight: centerRight,
+        );
+        break;
+    }
+  }
+
+  void paintBar(
+    Canvas canvas,
+    Size size, {
+    required RRect rrect,
+    required Paint line,
+    required Paint edges,
+    required Offset centerLeft,
+    required Offset centerRight,
+    required double halfLineWidth,
+  }) {
+    canvas.drawPath(
+      Path.combine(
+        PathOperation.union,
+        // DRAW TOP AND BOTTOM LINES
+        Path()
+          ..addRect(Rect.fromPoints(
+            rect.topLeft,
+            rect.topRight + Offset(0.0, line.strokeWidth),
+          ))
+          ..addRect(
+            Rect.fromPoints(
+              rect.bottomRight - Offset(line.strokeWidth, line.strokeWidth),
+              rect.bottomLeft,
+            ),
+          ),
+        // DRAW EDGES
+        Path()
+          ..addRRect(
+            RRect.fromRectAndCorners(
+              Rect.fromCenter(
+                center: centerLeft - Offset(halfLineWidth, 0),
+                width: style.edgesSize,
+                height: size.height,
+              ),
+              topLeft: Radius.circular(style.borderRadius),
+              bottomLeft: Radius.circular(style.borderRadius),
+            ),
+          )
+          ..addRRect(
+            RRect.fromRectAndCorners(
+              Rect.fromCenter(
+                center: centerRight + Offset(halfLineWidth, 0),
+                width: style.edgesSize,
+                height: size.height,
+              ),
+              topRight: Radius.circular(style.borderRadius),
+              bottomRight: Radius.circular(style.borderRadius),
+            ),
+          ),
+      ),
+      edges,
+    );
+
+    paintIcons(canvas);
+
+    paintIndicator(canvas, size);
+  }
+
+  void paintCircle(
+    Canvas canvas,
+    Size size, {
+    required RRect rrect,
+    required Paint line,
+    required Paint edges,
+    required Offset centerLeft,
+    required Offset centerRight,
+  }) {
     // DRAW RECT BORDERS
     canvas.drawRRect(rrect, line);
+
+    paintIndicator(canvas, size);
+
+    // LEFT CIRCLE
+    canvas.drawCircle(centerLeft, style.edgesSize, edges);
+    // RIGHT CIRCLE
+    canvas.drawCircle(centerRight, style.edgesSize, edges);
+
+    paintIcons(canvas);
+  }
+
+  void paintIndicator(Canvas canvas, Size size) {
+    final progress = Paint()
+      ..color = style.positionLineColor
+      ..strokeWidth = style.positionLineWidth;
 
     // DRAW VIDEO INDICATOR
     canvas.drawRRect(
@@ -63,44 +172,9 @@ class TrimSliderPainter extends CustomPainter {
       ),
       progress,
     );
+  }
 
-    final centerLeft = Offset(rect.left + halfLineWidth, halfHeight);
-    final centerRight = Offset(rect.right - halfLineWidth, halfHeight);
-
-    if (style.edgesType == TrimSliderEdgesType.circle) {
-      // LEFT CIRCLE
-      canvas.drawCircle(centerLeft, style.edgesSize, circle);
-      // RIGHT CIRCLE
-      canvas.drawCircle(centerRight, style.edgesSize, circle);
-    } else if (style.edgesType == TrimSliderEdgesType.bar) {
-      // LEFT RECT
-      canvas.drawRRect(
-        RRect.fromRectAndCorners(
-          Rect.fromCenter(
-            center: centerLeft - Offset(halfLineWidth, 0),
-            width: style.edgesSize,
-            height: size.height + style.lineWidth,
-          ),
-          topLeft: Radius.circular(style.borderRadius),
-          bottomLeft: Radius.circular(style.borderRadius),
-        ),
-        circle,
-      );
-      // RIGHT RECT
-      canvas.drawRRect(
-        RRect.fromRectAndCorners(
-          Rect.fromCenter(
-            center: centerRight + Offset(halfLineWidth, 0),
-            width: style.edgesSize,
-            height: size.height + style.lineWidth,
-          ),
-          topRight: Radius.circular(style.borderRadius),
-          bottomRight: Radius.circular(style.borderRadius),
-        ),
-        circle,
-      );
-    }
-
+  void paintIcons(Canvas canvas) {
     // LEFT ICON
     if (style.leftIcon != null) {
       TextPainter leftArrow = TextPainter(textDirection: TextDirection.rtl);
@@ -112,9 +186,12 @@ class TrimSliderPainter extends CustomPainter {
               color: style.iconColor));
       leftArrow.layout();
       leftArrow.paint(
-          canvas,
-          Offset(
-              rect.left - style.iconSize / 2, halfHeight - style.iconSize / 2));
+        canvas,
+        Offset(
+          rect.left - style.iconSize / 2,
+          rect.height / 2 - style.iconSize / 2,
+        ),
+      );
     }
 
     // RIGHT ICON
@@ -128,9 +205,12 @@ class TrimSliderPainter extends CustomPainter {
               color: style.iconColor));
       rightArrow.layout();
       rightArrow.paint(
-          canvas,
-          Offset(rect.right - style.iconSize / 2,
-              halfHeight - style.iconSize / 2));
+        canvas,
+        Offset(
+          rect.right - style.iconSize / 2,
+          rect.height / 2 - style.iconSize / 2,
+        ),
+      );
     }
   }
 

--- a/lib/ui/trim/trim_slider_painter.dart
+++ b/lib/ui/trim/trim_slider_painter.dart
@@ -24,49 +24,33 @@ class TrimSliderPainter extends CustomPainter {
       ..strokeWidth = style.positionLineWidth;
     final line = Paint()
       ..color = trimColor
-      ..strokeWidth = style.lineWidth
-      ..strokeCap = StrokeCap.square;
-    final double edgesSize = style.edgesSize;
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = style.lineWidth;
     final circle = Paint()..color = trimColor;
 
     final double halfLineWidth = style.lineWidth / 2;
     final double halfHeight = rect.height / 2;
 
-    // BACKGROUND LEFT
-    canvas.drawRect(
-      Rect.fromPoints(
-        Offset.zero,
-        rect.bottomLeft,
+    final rrect = RRect.fromRectAndRadius(
+      rect,
+      Radius.circular(style.borderRadius),
+    );
+
+    // DRAW LEFT AND RIGHT BACKGROUNDS
+    // extract [rect] trimmed area from the canvas
+    canvas.drawPath(
+      Path.combine(
+        PathOperation.difference,
+        Path()..addRect(Rect.fromLTWH(0, 0, size.width, size.height)),
+        Path()
+          ..addRRect(rrect)
+          ..close(),
       ),
       background,
     );
 
-    // BACKGROUND RIGHT
-    canvas.drawRect(
-      Rect.fromPoints(
-        rect.topRight,
-        Offset(size.width, size.height),
-      ),
-      background,
-    );
-
-    // TOP RECT
-    canvas.drawRect(
-      Rect.fromPoints(
-        rect.topLeft,
-        rect.topRight + Offset(0.0, line.strokeWidth),
-      ),
-      line,
-    );
-
-    // BOTTOM RECT
-    canvas.drawRect(
-      Rect.fromPoints(
-        rect.bottomRight - Offset(line.strokeWidth, line.strokeWidth),
-        rect.bottomLeft,
-      ),
-      line,
-    );
+    // DRAW RECT BORDERS
+    canvas.drawRRect(rrect, line);
 
     // DRAW VIDEO INDICATOR
     canvas.drawRRect(
@@ -84,42 +68,34 @@ class TrimSliderPainter extends CustomPainter {
     final centerRight = Offset(rect.right - halfLineWidth, halfHeight);
 
     if (style.edgesType == TrimSliderEdgesType.circle) {
-      // LEFT RECT
-      canvas.drawRect(
-        Rect.fromPoints(
-          rect.bottomLeft - Offset(-line.strokeWidth, line.strokeWidth),
-          rect.topLeft,
-        ),
-        line,
-      );
       // LEFT CIRCLE
-      canvas.drawCircle(centerLeft, edgesSize, circle);
-      // RIGHT RECT
-      canvas.drawRect(
-        Rect.fromPoints(
-          rect.topRight - Offset(line.strokeWidth, -line.strokeWidth),
-          rect.bottomRight,
-        ),
-        line,
-      );
+      canvas.drawCircle(centerLeft, style.edgesSize, circle);
       // RIGHT CIRCLE
-      canvas.drawCircle(centerRight, edgesSize, circle);
+      canvas.drawCircle(centerRight, style.edgesSize, circle);
     } else if (style.edgesType == TrimSliderEdgesType.bar) {
       // LEFT RECT
-      canvas.drawRect(
-        Rect.fromCenter(
-          center: centerLeft - Offset(halfLineWidth, 0),
-          width: edgesSize,
-          height: size.height,
+      canvas.drawRRect(
+        RRect.fromRectAndCorners(
+          Rect.fromCenter(
+            center: centerLeft - Offset(halfLineWidth, 0),
+            width: style.edgesSize,
+            height: size.height + style.lineWidth,
+          ),
+          topLeft: Radius.circular(style.borderRadius),
+          bottomLeft: Radius.circular(style.borderRadius),
         ),
         circle,
       );
       // RIGHT RECT
-      canvas.drawRect(
-        Rect.fromCenter(
-          center: centerRight + Offset(halfLineWidth, 0),
-          width: edgesSize,
-          height: size.height,
+      canvas.drawRRect(
+        RRect.fromRectAndCorners(
+          Rect.fromCenter(
+            center: centerRight + Offset(halfLineWidth, 0),
+            width: style.edgesSize,
+            height: size.height + style.lineWidth,
+          ),
+          topRight: Radius.circular(style.borderRadius),
+          bottomRight: Radius.circular(style.borderRadius),
         ),
         circle,
       );

--- a/lib/ui/trim/trim_timeline.dart
+++ b/lib/ui/trim/trim_timeline.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:video_editor/domain/bloc/controller.dart';
 
-class TrimTimeline extends StatefulWidget {
+class TrimTimeline extends StatelessWidget {
   /// Show the timeline corresponding to the [TrimSlider]
   const TrimTimeline({
     Key? key,
@@ -21,41 +21,29 @@ class TrimTimeline extends StatefulWidget {
   final EdgeInsets margin;
 
   @override
-  State<TrimTimeline> createState() => _TrimTimelineState();
-}
-
-class _TrimTimelineState extends State<TrimTimeline> {
-  int _timeGap = 0;
-
-  @override
-  void initState() {
-    final Duration duration =
-        widget.controller.maxDuration < widget.controller.videoDuration
-            ? widget.controller.maxDuration
-            : widget.controller.videoDuration;
-    _timeGap = (duration.inSeconds / (widget.secondGap + 1)).ceil();
-    super.initState();
-  }
-
-  @override
   Widget build(BuildContext context) {
-    return Container(
-        margin: widget.margin,
-        child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              for (int i = 0;
-                  i <=
-                      (widget.controller.videoDuration.inSeconds / _timeGap)
-                          .ceil();
-                  i++)
-                Text(
-                  (i * _timeGap <= widget.controller.videoDuration.inSeconds
-                          ? i * _timeGap
-                          : '')
-                      .toString(),
-                ),
-            ]));
+    final Duration duration = controller.maxDuration < controller.videoDuration
+        ? controller.maxDuration
+        : controller.videoDuration;
+    final timeGap = (duration.inSeconds / (secondGap + 1)).ceil();
+
+    return Padding(
+      padding: margin,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          for (int i = 0;
+              i <= (controller.videoDuration.inSeconds / timeGap).ceil();
+              i++)
+            Text(
+              (i * timeGap <= controller.videoDuration.inSeconds
+                      ? i * timeGap
+                      : '')
+                  .toString(),
+            ),
+        ],
+      ),
+    );
   }
 }

--- a/lib/ui/video_viewer.dart
+++ b/lib/ui/video_viewer.dart
@@ -2,51 +2,40 @@ import 'package:flutter/material.dart';
 import 'package:video_editor/domain/bloc/controller.dart';
 import 'package:video_player/video_player.dart';
 
-class VideoViewer extends StatefulWidget {
+class VideoViewer extends StatelessWidget {
   const VideoViewer({
     Key? key,
     required this.controller,
     this.child,
   }) : super(key: key);
 
-  final VideoEditorController? controller;
+  final VideoEditorController controller;
   final Widget? child;
-
-  @override
-  State<VideoViewer> createState() => _VideoViewerState();
-}
-
-class _VideoViewerState extends State<VideoViewer> {
-  late VideoPlayerController _controller;
-
-  @override
-  void initState() {
-    _controller = widget.controller!.video;
-    super.initState();
-  }
 
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
       onTap: () {
-        if (_controller.value.isPlaying) {
-          _controller.pause();
+        if (controller.video.value.isPlaying) {
+          controller.video.pause();
         } else {
-          _controller.play();
+          controller.video.play();
         }
       },
       child: Center(
-        child: Stack(children: [
-          AspectRatio(
-            aspectRatio: _controller.value.aspectRatio,
-            child: VideoPlayer(_controller),
-          ),
-          if (widget.child != null)
+        child: Stack(
+          children: [
             AspectRatio(
-              aspectRatio: _controller.value.aspectRatio,
-              child: widget.child,
+              aspectRatio: controller.video.value.aspectRatio,
+              child: VideoPlayer(controller.video),
             ),
-        ]),
+            if (child != null)
+              AspectRatio(
+                aspectRatio: controller.video.value.aspectRatio,
+                child: child,
+              ),
+          ],
+        ),
       ),
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   video_player: ^2.4.7
   video_thumbnail: ^0.5.3
   path: ^1.8.0 # update to `1.8.1` causes #79
+  transparent_image: ^2.0.0 # show fade-in placeholder in thumbnails generation
 
 dev_dependencies:
   flutter_test:

--- a/test/helpers_test.dart
+++ b/test/helpers_test.dart
@@ -141,4 +141,36 @@ void main() {
     test('centered 9/16 rect', () => expect(scaleToSize(maxSize, const Rect.fromLTRB(128.2, 0.0, 246.8, 210.9)), maxSize.height / 210.9));
     test('centered 1/1 rect', () => expect(scaleToSize(maxSize, const Rect.fromLTRB(51.4, 28.6, 314.7, 176.7)), maxSize.width / 263.3));
   });
+
+  group('getBestIndex', () {
+    test('max=4, length=11', () {
+      expect(getBestIndex(4, 11, 0), 1);
+      expect(getBestIndex(4, 11, 1), 4);
+      expect(getBestIndex(4, 11, 2), 7);
+      expect(getBestIndex(4, 11, 3), 9);
+    });
+
+    test('max=10, length=20', () {
+      expect(getBestIndex(10, 20, 0), 1);
+      expect(getBestIndex(10, 20, 1), 3);
+      expect(getBestIndex(10, 20, 2), 5);
+      expect(getBestIndex(10, 20, 3), 7);
+      expect(getBestIndex(10, 20, 4), 9);
+      expect(getBestIndex(10, 20, 5), 11);
+      expect(getBestIndex(10, 20, 6), 13);
+      expect(getBestIndex(10, 20, 7), 15);
+      expect(getBestIndex(10, 20, 8), 17);
+      expect(getBestIndex(10, 20, 9), 19);
+    });
+
+    test('max=120, length=213', () {
+      expect(getBestIndex(120, 213, 0), 1);
+      expect(getBestIndex(120, 213, 19), 35);
+      expect(getBestIndex(120, 213, 39), 70);
+      expect(getBestIndex(120, 213, 59), 106);
+      expect(getBestIndex(120, 213, 79), 141);
+      expect(getBestIndex(120, 213, 99), 177);
+      expect(getBestIndex(120, 213, 119), 212);
+    });
+  });
 }


### PR DESCRIPTION
### Controller
- new `isRotated` getter
- renamed getter `isTrimmmed` typo into `isTrimmed`

### TrimSlider
- 2 different styles possible `bar` and `circle`
- new `onTrimmingColor`, `onTrimmedColor`, `borderRadius` and `edgesSize` style params
- new fade in animation when thumbnails are generating
- thumbnails are regenerated if after edit changes there is not enough to fill the slider
- new `hasHaptic` param
- video position is updated better on indicator, start trim or end trim changes

### CoverSelection
- Removed indicators options of CoverSelectionStyle() and added `selectedCoverBuilder` param to custom selected cover widget
- New `wrap` param to customize the Wrap widget used to to display the cover thumbnails
- Renamed `height` param into `size`
- new fade in animation when thumbnails are generating
