### PR TITLE
Crop export values

### DIFF
--- a/lib/domain/thumbnails.dart
+++ b/lib/domain/thumbnails.dart
@@ -39,7 +39,7 @@ Stream<List<CoverData>> generateCoverThumbnails(
   int quality = 10,
 }) async* {
   final int duration = controller.isTrimmed
-      ? (controller.endTrim - controller.startTrim).inMilliseconds
+      ? controller.trimmedDuration.inMilliseconds
       : controller.videoDuration.inMilliseconds;
   final double eachPart = duration / quantity;
   List<CoverData> byteList = [];

--- a/lib/ui/crop/crop_grid.dart
+++ b/lib/ui/crop/crop_grid.dart
@@ -136,14 +136,9 @@ class _CropGridViewerState extends State<CropGridViewer> {
     );
   }
 
-  /// Return [Rect] expanded position to improve grab facility, the size will be equal to a single grid square
-  Rect _expandedPosition(Offset position) => Rect.fromCenter(
-        center: position,
-        // the width of one grid square
-        width: (_rect.value.width / _controller.cropStyle.gridSize),
-        // the height of one grid square
-        height: (_rect.value.height / _controller.cropStyle.gridSize),
-      );
+  /// Return [Rect] expanded position to improve touch detection
+  Rect _expandedPosition(Offset position) =>
+      Rect.fromCenter(center: position, width: 48, height: 48);
 
   /// Return expanded [Rect] to includes all corners [_expandedPosition]
   Rect _expandedRect() {

--- a/lib/ui/crop/crop_grid.dart
+++ b/lib/ui/crop/crop_grid.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:video_editor/domain/entities/transform_data.dart';
 import 'package:video_editor/domain/helpers.dart';
@@ -262,10 +264,10 @@ class _CropGridViewerState extends State<CropGridViewer> {
 
   /// Update [Rect] crop from incoming values, while respecting [_preferredCropAspectRatio]
   void _changeRect({double? left, double? top, double? right, double? bottom}) {
-    top = top ?? _rect.value.top;
-    left = left ?? _rect.value.left;
-    right = right ?? _rect.value.right;
-    bottom = bottom ?? _rect.value.bottom;
+    top = max(0, top ?? _rect.value.top);
+    left = max(0, left ?? _rect.value.left);
+    right = min(_layout.width, right ?? _rect.value.right);
+    bottom = min(_layout.height, bottom ?? _rect.value.bottom);
 
     // update crop height or width to adjust to the selected aspect ratio
     if (_preferredCropAspectRatio != null) {


### PR DESCRIPTION
- fix issue were crop was not applied at exportation
- crop edges touch detection is now fix to 48*48px
- new `trimmedDuration` getter
- fix issue when crop values = 0 were omitted
- no more floor() on the crop values to respect the selected crop values (anyway ffmpeg round it)